### PR TITLE
Add chapter/series pagination, inactivity auto-reset, AO3 outage alerts

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -15,10 +15,19 @@ import {
 import {
   buildLegacyWorkEmbed,
   buildWorkEmbedComponents,
+  buildWorkEmbedDefaultPayload,
   buildWorkEmbedPages,
 } from "./utils/embeds/worksEmbed.ts";
-import { buildUserEmbedComponents, buildUserEmbedPages } from "./utils/embeds/userEmbed.ts";
-import { buildWorkGalleryComponents, buildWorkGalleryPage } from "./utils/images.ts";
+import {
+  buildUserEmbedComponents,
+  buildUserEmbedDefaultPayload,
+  buildUserEmbedPages,
+} from "./utils/embeds/userEmbed.ts";
+import {
+  buildGalleryDefaultPayload,
+  buildWorkGalleryComponents,
+  buildWorkGalleryPage,
+} from "./utils/images.ts";
 import { cachedGetSeries, cachedGetWork } from "./utils/cache.ts";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -37,27 +46,28 @@ import {
   showTemporaryNotice,
 } from "./utils/urls.ts";
 
-import Bottleneck from "bottleneck";
+import { ao3Limiter } from "./utils/ao3Limiter.ts";
 import { authError } from "./utils/errors.ts";
-import { chapterEmbed } from "./utils/embeds/chapterEmbed.ts";
+import {
+  buildChapterEmbedComponents,
+  buildChapterEmbedDefaultPayload,
+  buildChapterEmbedPages,
+} from "./utils/embeds/chapterEmbed.ts";
 import dotenv from "dotenv";
 import { findBlockedTag } from "./utils/restrictions.ts";
 import fs from "node:fs";
 import { getBotCredentials } from "./utils/botEnv.ts";
-import { getWorkDetailsFromUrl } from "@fujocoded/ao3.js/urls";
+import { scheduleInactivityReset } from "./utils/inactivityReset.ts";
 import path from "node:path";
-import { seriesEmbed } from "./utils/embeds/seriesEmbed.ts";
+import {
+  buildSeriesEmbedComponents,
+  buildSeriesEmbedDefaultPayload,
+  buildSeriesEmbedPages,
+} from "./utils/embeds/seriesEmbed.ts";
+import { getWorkDetailsFromUrl } from "@fujocoded/ao3.js/urls";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-const ao3Limiter = new Bottleneck({
-  maxConcurrent: 1,
-  minTime: 2500,
-  reservoir: 20,
-  reservoirRefreshAmount: 20,
-  reservoirRefreshInterval: 60 * 1000,
-});
 
 dotenv.config({ quiet: true });
 
@@ -88,6 +98,11 @@ const client = new ClientWithCommands({
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent,
   ],
+});
+
+// Last-resort error handler — prevents an unhandled 'error' event from crashing the process.
+client.on(Events.Error, (error) => {
+  console.error("Discord client error:", error);
 });
 
 // Loads event listeners.
@@ -229,7 +244,7 @@ async function postWorkLink(message: any, url: string) {
           : [];
 
       const work = await cachedGetWork(workId);
-      await sendRedirectableEmbed(
+      const { message: sentMessage } = await sendRedirectableEmbed(
         message,
         { embeds, components },
         {
@@ -239,6 +254,13 @@ async function postWorkLink(message: any, url: string) {
         },
         waitingMsg,
       );
+
+      // Legacy embed mode has no tabs/pages to reset to.
+      if (!useLegacyEmbed) {
+        scheduleInactivityReset(sentMessage, () =>
+          buildWorkEmbedDefaultPayload(url, message.guildId, message.author.id),
+        );
+      }
     })
     .catch(async (error) => {
       abortGallery = true;
@@ -255,7 +277,7 @@ async function postWorkLink(message: any, url: string) {
       }
 
       const work = await cachedGetWork(workId);
-      await sendRedirectableEmbed(
+      const { message: sentMessage } = await sendRedirectableEmbed(
         message,
         {
           embeds: result.page.embeds,
@@ -272,6 +294,10 @@ async function postWorkLink(message: any, url: string) {
         },
         galleryWaitingMsg,
       );
+
+      scheduleInactivityReset(sentMessage, () =>
+        buildGalleryDefaultPayload(workId, message.guildId, message.author.id),
+      );
     })
     .catch(async (error) => {
       console.error(`Failed to build gallery for ${url}`, error);
@@ -280,6 +306,15 @@ async function postWorkLink(message: any, url: string) {
 }
 
 client.on(Events.MessageCreate, async (message) => {
+  try {
+    await handleMessageCreate(message);
+  } catch (error) {
+    // Prevents one bad message from crashing the whole shard.
+    console.error("Error handling message:", error);
+  }
+});
+
+async function handleMessageCreate(message: any) {
   // Tells bot to ignore messages from other bots.
   if (message.author.bot) return;
 
@@ -316,7 +351,7 @@ client.on(Events.MessageCreate, async (message) => {
         try {
           const username = getUsernameFromUrl(url);
           const pages = await ao3Limiter.schedule(() => buildUserEmbedPages(username, message.guildId));
-          await sendRedirectableEmbed(
+          const { message: sentMessage } = await sendRedirectableEmbed(
             message,
             {
               embeds: [pages[0]],
@@ -327,6 +362,10 @@ client.on(Events.MessageCreate, async (message) => {
             },
             { type: "user" },
             waitingMsg,
+          );
+
+          scheduleInactivityReset(sentMessage, () =>
+            buildUserEmbedDefaultPayload(username, message.guildId, message.author.id),
           );
         } catch (error) {
           console.error(`Failed to build user embed for ${url}`);
@@ -340,16 +379,30 @@ client.on(Events.MessageCreate, async (message) => {
         const waitingMsg = await message.channel.send("⏳ Fetching from AO3...");
         try {
           const seriesId = getSeriesIdFromUrl(url);
-          const [embed, series] = await ao3Limiter.schedule(() =>
-            Promise.all([seriesEmbed(url, message.guildId), cachedGetSeries(seriesId)]),
+          const [result, series] = await ao3Limiter.schedule(() =>
+            Promise.all([buildSeriesEmbedPages(url, message.guildId), cachedGetSeries(seriesId)]),
           );
           const fandoms = [...new Set(series.works.flatMap((w) => w.fandoms))];
+          const components =
+            result.pages.length > 1
+              ? buildSeriesEmbedComponents(
+                  message.author.id,
+                  0,
+                  result.notesPageCount,
+                  result.descriptionPageCount,
+                  seriesId,
+                )
+              : [];
 
-          await sendRedirectableEmbed(
+          const { message: sentMessage } = await sendRedirectableEmbed(
             message,
-            { embeds: [embed] },
+            { embeds: [result.pages[0]], components },
             { fandoms, type: "series" },
             waitingMsg,
+          );
+
+          scheduleInactivityReset(sentMessage, () =>
+            buildSeriesEmbedDefaultPayload(url, message.guildId, message.author.id),
           );
         } catch (error) {
           console.error(`Failed to build series embed for ${url}`, error);
@@ -377,7 +430,7 @@ client.on(Events.MessageCreate, async (message) => {
       });
     }
   }
-});
+}
 
 async function handleChapterLink(message: any, url: string) {
   const question = "Would you like a work or chapter embed?";
@@ -408,6 +461,28 @@ async function handleChapterLink(message: any, url: string) {
   });
 
   collector.on("collect", async (buttonInteraction: ButtonInteraction) => {
+    try {
+      await handleWorkOrChapterChoice(buttonInteraction, message, url, botReply);
+    } catch (error) {
+      console.error(`Failed to handle work/chapter choice for ${url}`, error);
+    }
+  });
+
+  collector.on("end", (collected: Collection<string, ButtonInteraction>) => {
+    console.log(`Collected ${collected.size} interactions.`);
+    // Nobody clicked in time — clean up instead of leaving dead buttons.
+    if (collected.size === 0) {
+      botReply.delete().catch(() => {});
+    }
+  });
+}
+
+async function handleWorkOrChapterChoice(
+  buttonInteraction: ButtonInteraction,
+  message: any,
+  url: string,
+  botReply: any,
+) {
     if (buttonInteraction.user.id !== message.author.id) {
       await buttonInteraction.reply({
         content: "These buttons aren't for you!",
@@ -460,16 +535,31 @@ async function handleChapterLink(message: any, url: string) {
           }
         }
 
-        const urlResponse = await ao3Limiter.schedule(() => chapterEmbed(url, message.guildId));
+        const result = await ao3Limiter.schedule(() => buildChapterEmbedPages(url, message.guildId));
 
-        if (urlResponse && "locked" in urlResponse) {
+        if ("locked" in result) {
           await waitingMsg.edit(authError);
           return;
         }
 
-        await sendRedirectableEmbed(
+        // Always present — this branch only runs for /chapters/ URLs (see handleChapterLink).
+        const chapterId = getWorkDetailsFromUrl({ url }).chapterId!;
+        const components =
+          result.pages.length > 1
+            ? buildChapterEmbedComponents(
+                message.author.id,
+                0,
+                result.tagsPageCount,
+                result.contentPageCount,
+                result.contentTabLabel,
+                workId,
+                chapterId,
+              )
+            : [];
+
+        const { message: sentMessage } = await sendRedirectableEmbed(
           message,
-          { embeds: [urlResponse] },
+          { embeds: [result.pages[0]], components },
           {
             rating: work.locked ? undefined : work.rating,
             fandoms: work.locked ? undefined : work.fandoms,
@@ -477,17 +567,16 @@ async function handleChapterLink(message: any, url: string) {
           },
           waitingMsg,
         );
+
+        scheduleInactivityReset(sentMessage, () =>
+          buildChapterEmbedDefaultPayload(url, message.guildId, message.author.id),
+        );
       } catch (error) {
         console.error(`Failed to build chapter embed for ${url}`);
         console.error(error);
         await waitingMsg.edit("⚠️ Something went wrong fetching that from AO3.").catch(() => {});
       }
     }
-  });
-
-  collector.on("end", (collected: Collection<string, ButtonInteraction>) => {
-    console.log(`Collected ${collected.size} interactions.`);
-  });
 }
 
 // Login to Discord and start bot.

--- a/commands/ao3/list.ts
+++ b/commands/ao3/list.ts
@@ -4,18 +4,27 @@ import {
   ButtonInteraction,
   ButtonStyle,
   ChatInputCommandInteraction,
+  MessageFlags,
   SlashCommandBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
+  StringSelectMenuOptionBuilder,
 } from "discord.js";
 
 import { ao3Embed } from "../../utils/baseEmbed.ts";
+import { ao3Limiter } from "../../utils/ao3Limiter.ts";
 import { ao3SeriesError } from "../../utils/errors.ts";
 import { cachedGetSeries } from "../../utils/cache.ts";
 import { constructCreators } from "../../utils/creators.ts";
+import { getGuildSettingsBundle, getListResetToFirstPage } from "../../utils/embedFields.ts";
 import { getSeriesIdFromUrl } from "../../utils/urls.ts";
 import { getSeriesUrl } from "@fujocoded/ao3.js/urls";
+import { ratingIcon } from "../../utils/ratings.ts";
+import { scheduleInactivityReset } from "../../utils/inactivityReset.ts";
 
 const MAX_DESCRIPTION = 4096;
 const MAX_WORKS_PER_PAGE = 10;
+const MAX_SELECT_OPTIONS = 25;
 
 type SeriesData = Awaited<ReturnType<typeof cachedGetSeries>>;
 
@@ -40,7 +49,8 @@ async function getListSession(seriesId: string): Promise<ListSession> {
   const cached = sessionCache.get(seriesId);
   if (cached) return cached;
 
-  const series = await cachedGetSeries(seriesId);
+  // Rate-limited fetch — long series can mean several AO3 requests.
+  const series = await ao3Limiter.schedule(() => cachedGetSeries(seriesId));
   const authors = constructCreators(series.authors, series.authors?.[0]?.anonymous);
   const seriesURL = getSeriesUrl({ seriesId });
   const pageBoundaries = computePageBoundaries(series, authors);
@@ -48,6 +58,12 @@ async function getListSession(seriesId: string): Promise<ListSession> {
   const session: ListSession = { series, seriesURL, authors, pageBoundaries };
   sessionCache.set(seriesId, session);
   return session;
+}
+
+// Formats one work line, with a rating icon.
+function formatWorkLine(index: number, work: SeriesData["works"][number]): string {
+  const icon = ratingIcon(work);
+  return `${index + 1}. ${icon ? `${icon} ` : ""}[${work.title}](${work.url})`;
 }
 
 function computePageBoundaries(
@@ -61,7 +77,7 @@ function computePageBoundaries(
 
   for (let i = 0; i < series.works.length; i++) {
     const work = series.works[i];
-    const line = `${i + 1}. [${work.title}](${work.url})\n`;
+    const line = `${formatWorkLine(i, work)}\n`;
 
     const wouldExceedLength = currentLength + line.length > MAX_DESCRIPTION;
     const wouldExceedCount = itemsOnPage >= MAX_WORKS_PER_PAGE;
@@ -94,7 +110,7 @@ function buildListEmbed(
   const pageWorks = series.works.slice(start, end);
 
   const workList = pageWorks
-    .map((work, i) => `${start + i + 1}. [${work.title}](${work.url})`)
+    .map((work, i) => formatWorkLine(start + i, work))
     .join("\n");
 
   const embed = ao3Embed()
@@ -108,13 +124,59 @@ function buildListEmbed(
   return { embed, page, pageCount };
 }
 
+// Page-jump dropdown — windowed to Discord's 25-option cap.
+function buildListPageSelectRow(
+  ownerId: string,
+  page: number,
+  pageBoundaries: number[],
+  totalWorks: number,
+  seriesId: string,
+) {
+  const pageCount = pageBoundaries.length;
+  const windowStart =
+    pageCount <= MAX_SELECT_OPTIONS
+      ? 0
+      : Math.max(0, Math.min(page - Math.floor(MAX_SELECT_OPTIONS / 2), pageCount - MAX_SELECT_OPTIONS));
+  const windowEnd = Math.min(windowStart + MAX_SELECT_OPTIONS, pageCount);
+
+  const options = [];
+  for (let i = windowStart; i < windowEnd; i++) {
+    const start = pageBoundaries[i] + 1;
+    const end = pageBoundaries[i + 1] ?? totalWorks;
+    options.push(
+      new StringSelectMenuOptionBuilder()
+        .setLabel(`Page ${i + 1}: ${start}-${end}`)
+        .setValue(String(i))
+        .setDefault(i === page),
+    );
+  }
+
+  const currentStart = pageBoundaries[page] + 1;
+  const currentEnd = pageBoundaries[page + 1] ?? totalWorks;
+
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(`list-select:${ownerId}:${seriesId}`)
+      .setPlaceholder(`Page ${page + 1} of ${pageCount}: works ${currentStart}-${currentEnd}`)
+      .addOptions(options),
+  );
+}
+
 function buildListComponents(
   ownerId: string,
   page: number,
-  pageCount: number,
+  pageBoundaries: number[],
+  totalWorks: number,
   seriesId: string,
 ) {
-  return [
+  const pageCount = pageBoundaries.length;
+  const rows = [];
+
+  if (pageCount > 1) {
+    rows.push(buildListPageSelectRow(ownerId, page, pageBoundaries, totalWorks, seriesId));
+  }
+
+  rows.push(
     new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
         .setCustomId(`list:${ownerId}:${page - 1}:${seriesId}`)
@@ -127,7 +189,36 @@ function buildListComponents(
         .setStyle(ButtonStyle.Secondary)
         .setDisabled(page >= pageCount - 1),
     ),
-  ];
+  );
+
+  return rows;
+}
+
+// Default-page payload for the inactivity auto-reset.
+async function buildListDefaultPayload(
+  seriesId: string,
+  guildId: string | null | undefined,
+  ownerId: string,
+): Promise<{ embeds: ReturnType<typeof ao3Embed>[]; components: ReturnType<typeof buildListComponents> | [] } | null> {
+  const bundle = await getGuildSettingsBundle(guildId);
+  if (!getListResetToFirstPage(bundle)) return null;
+
+  const session = await getListSession(seriesId);
+  const { embed, page, pageCount } = buildListEmbed(
+    session.series,
+    session.seriesURL,
+    session.authors,
+    session.pageBoundaries,
+    0,
+  );
+
+  return {
+    embeds: [embed],
+    components:
+      pageCount > 1
+        ? buildListComponents(ownerId, page, session.pageBoundaries, session.series.works.length, seriesId)
+        : [],
+  };
 }
 
 export const data = new SlashCommandBuilder()
@@ -165,13 +256,23 @@ export const execute = async (interaction: ChatInputCommandInteraction) => {
     0,
   );
 
-  await interaction.editReply({
+  const message = await interaction.editReply({
     embeds: [embed],
     components:
       pageCount > 1
-        ? buildListComponents(interaction.user.id, page, pageCount, seriesId)
+        ? buildListComponents(
+            interaction.user.id,
+            page,
+            session.pageBoundaries,
+            session.series.works.length,
+            seriesId,
+          )
         : [],
   });
+
+  scheduleInactivityReset(message, () =>
+    buildListDefaultPayload(seriesId, interaction.guildId, interaction.user.id),
+  );
 };
 
 export const handleListButtonInteraction = async (
@@ -181,20 +282,21 @@ export const handleListButtonInteraction = async (
   if (parts[0] !== "list") return false;
 
   const [, ownerId, pageText, seriesId] = parts;
+  const isOwner = interaction.user.id === ownerId;
+  const componentOwnerId = isOwner ? ownerId : interaction.user.id;
 
-  if (interaction.user.id !== ownerId) {
-    await interaction.reply({
-      content:
-        "This list belongs to someone else. Run `/list` for your own copy.",
-      flags: 64,
-    });
-    return true;
+  // Defer immediately — getListSession can be slow on a cache miss.
+  // Non-owners get their own ephemeral copy.
+  if (isOwner) {
+    await interaction.deferUpdate();
+  } else {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
   }
 
   const session = await getListSession(seriesId);
 
   const page = parseInt(pageText, 10) || 0;
-  const { embed, page: safePage, pageCount } = buildListEmbed(
+  const { embed, page: safePage } = buildListEmbed(
     session.series,
     session.seriesURL,
     session.authors,
@@ -202,10 +304,76 @@ export const handleListButtonInteraction = async (
     page,
   );
 
-  await interaction.update({
+  await interaction.editReply({
     embeds: [embed],
-    components: buildListComponents(ownerId, safePage, pageCount, seriesId),
+    components:
+      session.pageBoundaries.length > 1
+        ? buildListComponents(
+            componentOwnerId,
+            safePage,
+            session.pageBoundaries,
+            session.series.works.length,
+            seriesId,
+          )
+        : [],
   });
+
+  if (isOwner) {
+    scheduleInactivityReset(interaction.message, () =>
+      buildListDefaultPayload(seriesId, interaction.guildId, ownerId),
+    );
+  }
+
+  return true;
+};
+
+export const handleListSelectInteraction = async (
+  interaction: StringSelectMenuInteraction,
+): Promise<boolean> => {
+  const parts = interaction.customId.split(":");
+  if (parts[0] !== "list-select") return false;
+
+  const [, ownerId, seriesId] = parts;
+  const isOwner = interaction.user.id === ownerId;
+  const componentOwnerId = isOwner ? ownerId : interaction.user.id;
+
+  // Defer immediately — non-owners get their own ephemeral copy.
+  if (isOwner) {
+    await interaction.deferUpdate();
+  } else {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  }
+
+  const session = await getListSession(seriesId);
+
+  const page = parseInt(interaction.values[0], 10) || 0;
+  const { embed, page: safePage } = buildListEmbed(
+    session.series,
+    session.seriesURL,
+    session.authors,
+    session.pageBoundaries,
+    page,
+  );
+
+  await interaction.editReply({
+    embeds: [embed],
+    components:
+      session.pageBoundaries.length > 1
+        ? buildListComponents(
+            componentOwnerId,
+            safePage,
+            session.pageBoundaries,
+            session.series.works.length,
+            seriesId,
+          )
+        : [],
+  });
+
+  if (isOwner) {
+    scheduleInactivityReset(interaction.message, () =>
+      buildListDefaultPayload(seriesId, interaction.guildId, ownerId),
+    );
+  }
 
   return true;
 };

--- a/db/index.ts
+++ b/db/index.ts
@@ -13,4 +13,10 @@ if (!databaseUrl) {
 // database (as opposed to "planetscale", which doesn't support them) — true
 // for MariaDB/MySQL, and needed for the guildSettings.id -> *.guildSettingsId
 // cascade deletes defined in schema.ts to actually work as declared.
-export const db = drizzle(databaseUrl, { schema, mode: "default" });
+//
+// enableKeepAlive avoids ECONNRESET on idle pool connections.
+export const db = drizzle({
+  connection: { uri: databaseUrl, enableKeepAlive: true, keepAliveInitialDelay: 10_000 },
+  schema,
+  mode: "default",
+});

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -38,11 +38,17 @@ export const guildSettings = table("guild_settings", {
 
   // General category.
   legacyWorkEmbed: t.boolean().default(false).notNull(),
+  // AO3 outage alerts.
+  outageAlertsEnabled: t.boolean().default(false).notNull(),
+  outageAlertChannelId: t.varchar({ length: 20 }),
 
   // Gallery category.
   galleryEnabled: t.boolean().default(true).notNull(),
   galleryNsfwWarningMature: t.boolean().default(true).notNull(),
   galleryNsfwWarningExplicit: t.boolean().default(true).notNull(),
+  // Inactivity auto-reset.
+  galleryResetToFirstPage: t.boolean().default(true).notNull(),
+  listResetToFirstPage: t.boolean().default(true).notNull(),
 
   // Ratings category — a work/chapter with a disallowed rating is blocked
   // from being posted at all (see isRatingAllowed in utils/embedFields.ts).
@@ -104,6 +110,9 @@ export const workFieldSettings = table("work_field_settings", {
   // work-summary
   showSummary: t.boolean().default(true).notNull(),
   summaryMaxLength: t.int().default(3000).notNull(),
+
+  // Inactivity auto-reset: default tab.
+  defaultTab: t.mysqlEnum(["stats", "tags", "summary", "none"]).default("stats").notNull(),
 });
 
 /**
@@ -129,6 +138,16 @@ export const chapterFieldSettings = table("chapter_field_settings", {
   showNotes: t.boolean().default(true).notNull(),
   notesMaxLength: t.int().default(1024).notNull(),
 
+  // Tags tab (reuses the work's tags).
+  showFandoms: t.boolean().default(true).notNull(),
+  fandomsMaxLength: t.int().default(1024).notNull(),
+  showRelationships: t.boolean().default(true).notNull(),
+  relationshipsMaxLength: t.int().default(1024).notNull(),
+  showCharacters: t.boolean().default(true).notNull(),
+  charactersMaxLength: t.int().default(1024).notNull(),
+  showTags: t.boolean().default(true).notNull(),
+  tagsMaxLength: t.int().default(1024).notNull(),
+
   // Thumbnail: its own settings category (see EMBED_FIELD_CATEGORIES in
   // utils/embedFields.ts) rather than bundled into the general Fields
   // checkbox group, so it can carry its own rating-based exclusions instead
@@ -137,6 +156,9 @@ export const chapterFieldSettings = table("chapter_field_settings", {
   showThumbnail: t.boolean().default(true).notNull(),
   hideThumbnailOnMature: t.boolean().default(false).notNull(),
   hideThumbnailOnExplicit: t.boolean().default(false).notNull(),
+
+  // Inactivity auto-reset: default tab.
+  defaultTab: t.mysqlEnum(["stats", "tags", "summary", "none"]).default("stats").notNull(),
 });
 
 /**
@@ -160,6 +182,9 @@ export const seriesFieldSettings = table("series_field_settings", {
   notesMaxLength: t.int().default(1024).notNull(),
   showDescription: t.boolean().default(true).notNull(),
   descriptionMaxLength: t.int().default(1024).notNull(),
+
+  // Inactivity auto-reset: default tab.
+  defaultTab: t.mysqlEnum(["stats", "notes", "description", "none"]).default("stats").notNull(),
 });
 
 /**
@@ -185,6 +210,9 @@ export const userFieldSettings = table("user_field_settings", {
   // before it spills onto its own paginated bio page(s), see userEmbed.ts.
   showBio: t.boolean().default(true).notNull(),
   bioMaxLength: t.int().default(6000).notNull(),
+
+  // Inactivity auto-reset.
+  resetToFirstPage: t.boolean().default(true).notNull(),
 });
 
 /**
@@ -213,9 +241,9 @@ export const blockedTags = table(
  * an arbitrary filter object (rating / fandom / type, AND'd together
  * within a rule) and a destination channel/forum/thread ID.
  *
- * Match priority across multiple matching rules, when more than one rule
- * matches the same work: rating > fandom > type (computed at match time
- * in bot.ts, not stored — see ruleSpecificity()).
+ * When more than one rule matches the same work, the first one created
+ * wins (see resolveRedirectRule in utils/redirects.ts) — there's no
+ * specificity-based priority between rating/fandom/type.
  */
 export const redirectRules = table(
   "redirect_rules",

--- a/events/interactionCreate.ts
+++ b/events/interactionCreate.ts
@@ -11,8 +11,10 @@ import {
 } from "../utils/images.ts";
 
 import type { ClientWithCommands } from "../bot.ts";
+import { handleChapterEmbedButtonInteraction } from "../utils/embeds/chapterEmbed.ts";
 import { handleHelpButtonInteraction } from "../commands/general/help.ts";
-import { handleListButtonInteraction } from "../commands/ao3/list.ts";
+import { handleListButtonInteraction, handleListSelectInteraction } from "../commands/ao3/list.ts";
+import { handleSeriesEmbedButtonInteraction } from "../utils/embeds/seriesEmbed.ts";
 import { handleUserEmbedButtonInteraction } from "../utils/embeds/userEmbed.ts";
 import { handleWorkEmbedButtonInteraction } from "../utils/embeds/worksEmbed.ts";
 
@@ -24,6 +26,8 @@ export const execute = async (interaction: BaseInteraction) => {
       if (await handleWorkEmbedButtonInteraction(interaction)) return;
       if (await handleWorkGalleryButtonInteraction(interaction)) return;
       if (await handleUserEmbedButtonInteraction(interaction)) return;
+      if (await handleChapterEmbedButtonInteraction(interaction)) return;
+      if (await handleSeriesEmbedButtonInteraction(interaction)) return;
       if (await handleListButtonInteraction(interaction)) return;
       if (await handleSettingsPanelButtonInteraction(interaction)) return;
     } catch (error) {
@@ -34,6 +38,7 @@ export const execute = async (interaction: BaseInteraction) => {
   if (interaction.isStringSelectMenu()) {
     try {
       if (await handleWorkGallerySelectInteraction(interaction)) return;
+      if (await handleListSelectInteraction(interaction)) return;
       if (await handleSettingsPanelSelectInteraction(interaction)) return;
     } catch (error) {
       console.error("Error handling select menu interaction:", error);

--- a/events/ready.ts
+++ b/events/ready.ts
@@ -2,6 +2,7 @@ import { ActivityType, Events } from "discord.js";
 
 import type { ClientWithCommands } from "../bot.ts";
 import { loadEmojis } from "../utils/emojis.ts";
+import { startOutageMonitor } from "../utils/otwStatus.ts";
 
 export const name = Events.ClientReady;
 export const once = true;
@@ -11,5 +12,6 @@ export const execute = async (client: ClientWithCommands) => {
   client.user?.setPresence({
 		activities: [{ name: `archivistbot.com`, type: ActivityType.Watching }],
 		status: 'online', });
+  startOutageMonitor(client);
   console.log(`Ready! Logged in as ${client.user?.tag}`);
 };

--- a/patches/@fujocoded+ao3.js+0.23.1.patch
+++ b/patches/@fujocoded+ao3.js+0.23.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@fujocoded/ao3.js/dist/src/page-loaders.js b/node_modules/@fujocoded/ao3.js/dist/src/page-loaders.js
-index 8b00568..e523d43 100644
+index 8b00568..c875c43 100644
 --- a/node_modules/@fujocoded/ao3.js/dist/src/page-loaders.js
 +++ b/node_modules/@fujocoded/ao3.js/dist/src/page-loaders.js
 @@ -19,10 +19,9 @@ const loadTagFeedAtomPage = async ({ tagId }) => {
@@ -16,6 +16,91 @@ index 8b00568..e523d43 100644
  };
  const loadUserProfilePage = async ({ username }) => {
  	return await fetchPage({ url: getUserProfileUrl({ username }) });
+@@ -30,8 +29,10 @@ const loadUserProfilePage = async ({ username }) => {
+ const loadChaptersIndexPage = async ({ workId }) => {
+ 	return await fetchPage({ url: getWorkIndexUrl({ workId }) });
+ };
+-const loadSeriesPage = async (seriesId) => {
+-	return await fetchPage({ url: getSeriesUrl({ seriesId }) });
++const loadSeriesPage = async (seriesId, page) => {
++	const base = getSeriesUrl({ seriesId });
++	const url = page && page > 1 ? `${base}?page=${page}` : base;
++	return await fetchPage({ url });
+ };
+ 
+ //#endregion
+diff --git a/node_modules/@fujocoded/ao3.js/dist/src/series/getters.js b/node_modules/@fujocoded/ao3.js/dist/src/series/getters.js
+index b7739da..06e36c9 100644
+--- a/node_modules/@fujocoded/ao3.js/dist/src/series/getters.js
++++ b/node_modules/@fujocoded/ao3.js/dist/src/series/getters.js
+@@ -1,6 +1,7 @@
+ import { parseArchiveId } from "../utils.js";
+ import { getAsShortUrl, getWorkDetailsFromUrl, getWorkUrl } from "../../urls.js";
+ import { getWorkBookmarkCount, getWorkHits, getWorkKudosCount, getWorkLanguage, getWorkPublishedChapters, getWorkTotalChapters, getWorkWordCount } from "../works/work-getters.js";
++import { WorkRatings } from "../../types/entities.js";
+ import { load } from "cheerio/slim";
+ 
+ //#region src/series/getters.ts
+@@ -73,6 +74,10 @@ const getSeriesWorks = ($seriesPage) => {
+ 	});
+ 	return works;
+ };
++const getSeriesWorkRating = ($work) => {
++	const rating = $work("span.rating").attr("title") ?? "";
++	return Object.values(WorkRatings).includes(rating) ? rating : WorkRatings.NOT_RATED;
++};
+ const getSeriesWork = (workHtml) => {
+ 	const work = load(workHtml);
+ 	const $work = work, $$work = work;
+@@ -88,6 +93,7 @@ const getSeriesWork = (workHtml) => {
+ 		title: getSeriesWorkTitle($work),
+ 		updatedAt: getSeriesWorkUpdateDate($work),
+ 		summary: getSeriesWorkSummary($work),
++		rating: getSeriesWorkRating($work),
+ 		adult: false,
+ 		fandoms: getSeriesWorkFandoms($work),
+ 		tags: {
+diff --git a/node_modules/@fujocoded/ao3.js/dist/src/series/index.js b/node_modules/@fujocoded/ao3.js/dist/src/series/index.js
+index b4710ad..90fb24b 100644
+--- a/node_modules/@fujocoded/ao3.js/dist/src/series/index.js
++++ b/node_modules/@fujocoded/ao3.js/dist/src/series/index.js
+@@ -3,10 +3,26 @@ import { loadSeriesPage } from "../page-loaders.js";
+ import { getSeriesAuthors, getSeriesBookmarkCount, getSeriesCompletionStatus, getSeriesDescription, getSeriesNotes, getSeriesPublishDate, getSeriesTitle, getSeriesUpdateDate, getSeriesWordCount, getSeriesWorkCount, getSeriesWorks } from "./getters.js";
+ 
+ //#region src/series/index.ts
++// AO3 paginates a series' works list at 20/page — getSeriesWorks only ever
++// sees whatever's on the single page it's given, so without this a series
++// with more than 20 works would silently report just its first page. Capped
++// at MAX_SERIES_PAGES (1000 works) so a pathologically long rec-list series
++// can't turn one getSeries() call into an unbounded number of requests.
++const SERIES_WORKS_PER_PAGE = 20;
++const MAX_SERIES_PAGES = 50;
++const SERIES_PAGE_FETCH_DELAY_MS = 300;
++const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+ const getSeries = async ({ seriesId }) => {
+ 	if (!isValidArchiveId(seriesId)) throw new InvalidIDError(seriesId, "series");
+ 	const seriesPage = await loadSeriesPage(seriesId);
+-	const seriesWorks = getSeriesWorks(seriesPage);
++	const workCount = getSeriesWorkCount(seriesPage);
++	let seriesWorks = getSeriesWorks(seriesPage);
++	const totalPages = Math.min(Math.ceil((workCount || seriesWorks.length) / SERIES_WORKS_PER_PAGE) || 1, MAX_SERIES_PAGES);
++	for (let page = 2; page <= totalPages; page++) {
++		await sleep(SERIES_PAGE_FETCH_DELAY_MS);
++		const nextPage = await loadSeriesPage(seriesId, page);
++		seriesWorks = seriesWorks.concat(getSeriesWorks(nextPage));
++	}
+ 	return {
+ 		id: parseArchiveId(seriesId),
+ 		name: getSeriesTitle(seriesPage),
+@@ -18,7 +34,7 @@ const getSeries = async ({ seriesId }) => {
+ 		words: getSeriesWordCount(seriesPage),
+ 		bookmarks: getSeriesBookmarkCount(seriesPage),
+ 		complete: getSeriesCompletionStatus(seriesPage),
+-		workCount: getSeriesWorkCount(seriesPage),
++		workCount,
+ 		works: seriesWorks
+ 	};
+ };
 diff --git a/node_modules/@fujocoded/ao3.js/dist/src/works/index.js b/node_modules/@fujocoded/ao3.js/dist/src/works/index.js
 index 1660847..4d9fbdc 100644
 --- a/node_modules/@fujocoded/ao3.js/dist/src/works/index.js
@@ -107,9 +192,18 @@ index c4f20b7..9c5c966 100644
 +export { getChapterIndex, getChapterName, getChapterStartNotes, getChapterSummary, getWorkAdditionalTags, getWorkAdult, getWorkAuthors, getWorkBookmarkCount, getWorkCategory, getWorkCharacters, getWorkCommentCount, getWorkContentHtml, getWorkContentSummary, getWorkEndNotes, getWorkFandoms, getWorkHits, getWorkKudosCount, getWorkLanguage, getWorkLocked, getWorkPublishDate, getWorkPublishedChapters, getWorkRating, getWorkRelationships, getWorkSeries, getWorkStartNotes, getWorkSummary, getWorkTitle, getWorkTotalChapters, getWorkUpdateDate, getWorkWarnings, getWorkWordCount };
 \ No newline at end of file
 diff --git a/node_modules/@fujocoded/ao3.js/dist/types/entities.d.ts b/node_modules/@fujocoded/ao3.js/dist/types/entities.d.ts
-index 4984a90..0499b2a 100644
+index 4984a90..75e002b 100644
 --- a/node_modules/@fujocoded/ao3.js/dist/types/entities.d.ts
 +++ b/node_modules/@fujocoded/ao3.js/dist/types/entities.d.ts
+@@ -62,7 +62,7 @@ interface User {
+   gifts: number;
+   bioHtml: string | null;
+ }
+-interface SeriesWorkSummary extends Omit<WorkSummary, "category" | "publishedAt" | "rating" | "tags" | "stats" | "locked" | "chapterInfo" | "series"> {
++interface SeriesWorkSummary extends Omit<WorkSummary, "category" | "publishedAt" | "tags" | "stats" | "locked" | "chapterInfo" | "series"> {
+   url: string;
+   shortUrl: string;
+   tags: Omit<WorkSummary["tags"], "warnings">;
 @@ -128,6 +128,7 @@ interface WorkSummary {
    publishedAt: string;
    updatedAt: string | null;

--- a/utils/ao3Limiter.ts
+++ b/utils/ao3Limiter.ts
@@ -1,0 +1,10 @@
+import Bottleneck from "bottleneck";
+
+// Shared AO3 rate limiter, used bot-wide.
+export const ao3Limiter = new Bottleneck({
+  maxConcurrent: 1,
+  minTime: 2500,
+  reservoir: 20,
+  reservoirRefreshAmount: 20,
+  reservoirRefreshInterval: 60 * 1000,
+});

--- a/utils/baseEmbed.ts
+++ b/utils/baseEmbed.ts
@@ -13,6 +13,5 @@ export function ao3Embed(color: number | null = DEFAULT_EMBED_COLOR): EmbedBuild
       iconURL: AO3_ICON_URL,
       url: AO3_URL,
     })
-    .setTimestamp()
     .setFooter({ text: AO3_FOOTER_TEXT });
 }

--- a/utils/cache.ts
+++ b/utils/cache.ts
@@ -1,4 +1,4 @@
-import { getSeries, getUser, getWork, getWorkContent, getWorkWithChapters } from "@fujocoded/ao3.js";
+import { getSeries, getUser, getWork, getWorkContent, getWorkWithChapters, setFetcher } from "@fujocoded/ao3.js";
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 3 * HOUR_MS;
@@ -97,7 +97,15 @@ export async function cachedGetWork(workId: CacheKey) {
 }
 
 export async function cachedGetSeries(seriesId: CacheKey) {
-  return seriesCache.getOrSet(seriesId, () => getSeries({ seriesId }));
+  return seriesCache.getOrSet(seriesId, async () => {
+    const series = await getSeries({ seriesId });
+    // Unlike getWork, ao3.js's series parser doesn't validate the page
+    // actually parsed — an incomplete/broken AO3 response comes back as a
+    // "successful" series with an empty name and no works instead of
+    // throwing, which would otherwise get cached as good data for an hour.
+    if (!series.name) throw new Error("Series name is empty — AO3 likely returned an incomplete page");
+    return series;
+  });
 }
 
 export async function cachedGetUser(username: string) {
@@ -123,3 +131,22 @@ export async function cachedGetWorkContent(workId: CacheKey, chapterId?: number)
   const key = chapterCacheKey(workId, chapterId);
   return workContentCache.getOrSet(key, () => getWorkContent({ workId, chapterId }));
 }
+
+// Shared raw-HTML cache for every ao3.js fetch, wired in via setFetcher
+// below so images.ts's gallery scraping doesn't re-fetch the same page.
+const rawHtmlCache = new Cache<string>(HOUR_MS);
+
+export async function cachedFetchText(url: string, cookie: string = ""): Promise<string> {
+  const key = `${url}::${cookie}`;
+  return rawHtmlCache.getOrSet(key, async () => {
+    const response = await fetch(url, cookie ? { headers: { Cookie: cookie } } : undefined);
+    return response.text();
+  });
+}
+
+setFetcher(async (input, init) => {
+  const url = typeof input === "string" ? input : input.toString();
+  const headers = init?.headers as Record<string, string> | undefined;
+  const text = await cachedFetchText(url, headers?.Cookie ?? "");
+  return new Response(text);
+});

--- a/utils/chunkText.ts
+++ b/utils/chunkText.ts
@@ -10,3 +10,14 @@ export function chunkText(text: string, maxLength = 1024): string[] {
   if (remaining.length > 0) chunks.push(remaining);
   return chunks;
 }
+
+// chunkText, but a too-short trailing chunk gets folded into the one before
+// it instead of becoming its own near-empty final page.
+export function chunkTextMerged(text: string, maxLength: number, mergeThreshold = 250): string[] {
+  const chunks = chunkText(text, maxLength);
+  if (chunks.length >= 2 && chunks[chunks.length - 1].length < mergeThreshold) {
+    const last = chunks.pop()!;
+    chunks[chunks.length - 1] += "\n" + last;
+  }
+  return chunks;
+}

--- a/utils/embedFields.ts
+++ b/utils/embedFields.ts
@@ -24,8 +24,7 @@ const MIN_FIELD_MAX_LENGTH = 50;
 export interface FieldDef {
   key: string;
   label: string;
-  // Shown next to the checkbox in the settings modal. Discord caps this at
-  // 100 characters.
+  // Shown next to the checkbox in the settings modal. Discord caps this at 100 characters.
   description?: string;
   // Presence marks this field as length-configurable in the settings panel.
   // The value is the default max length before a guild overrides it.
@@ -40,9 +39,7 @@ export interface FieldDef {
   defaultEnabled?: boolean;
 }
 
-// Each category maps 1:1 to a CheckboxGroup modal. Discord caps a
-// CheckboxGroup at 10 options, which is why "work" is split into several
-// small categories (stats/tags/summary) instead of one big one.
+// Each category maps 1:1 to a CheckboxGroup modal. Discord caps a CheckboxGroup at 10 options
 export const EMBED_FIELD_CATEGORIES = {
   general: {
     title: "Preferences",
@@ -57,6 +54,12 @@ export const EMBED_FIELD_CATEGORIES = {
         key: "legacyWorkEmbed",
         label: "Use the original Archivist-style embed",
         description: "One embed including all fields, instead of paginated Stats/Tags/Summary tabs.",
+        defaultEnabled: false,
+      },
+      {
+        key: "outageAlerts",
+        label: "Post AO3 outage alerts",
+        description: "Posts to the channel set below whenever AO3's status changes, and again on recovery.",
         defaultEnabled: false,
       },
     ] as FieldDef[],
@@ -136,6 +139,17 @@ export const EMBED_FIELD_CATEGORIES = {
       },
     ] as FieldDef[],
   },
+  // Inactivity auto-reset: default tab + gallery reset toggle.
+  "work-inactivity": {
+    title: "Inactivity",
+    fields: [
+      {
+        key: "galleryResetToFirstPage",
+        label: "Reset gallery to page 1 after inactivity",
+        description: "The original gallery message jumps back to page 1 after 5 minutes with no clicks.",
+      },
+    ] as FieldDef[],
+  },
   // Subcategory of Restrictions — a work with a disallowed rating is
   // blocked from being posted at all, same as a blocked warning/tag.
   ratings: {
@@ -179,13 +193,44 @@ export const EMBED_FIELD_CATEGORIES = {
       {
         key: "summary",
         label: "Summary",
-        description: "This chapter's summary, if the author wrote one.",
-        maxLength: FIELD_VALUE_HARD_CAP,
+        description: "Adds a Summary tab with this chapter's summary, paginated if it's long.",
+        maxLength: 3000,
+        maxLengthCap: 10000,
       },
       {
         key: "notes",
         label: "Notes",
-        description: "This chapter's own beginning/end author notes, not the work's.",
+        description: "This chapter's beginning/end author notes — merged into Summary if present, else its own tab.",
+        maxLength: 3000,
+        maxLengthCap: 10000,
+      },
+    ] as FieldDef[],
+  },
+  "chapter-tags": {
+    title: "Tags",
+    fields: [
+      {
+        key: "fandoms",
+        label: "Fandoms",
+        description: "Which fandom(s) the work belongs to.",
+        maxLength: FIELD_VALUE_HARD_CAP,
+      },
+      {
+        key: "relationships",
+        label: "Relationships",
+        description: "Tagged relationships.",
+        maxLength: FIELD_VALUE_HARD_CAP,
+      },
+      {
+        key: "characters",
+        label: "Characters",
+        description: "Tagged characters featured in the work.",
+        maxLength: FIELD_VALUE_HARD_CAP,
+      },
+      {
+        key: "tags",
+        label: "Additional Tags",
+        description: "Freeform tags the author added.",
         maxLength: FIELD_VALUE_HARD_CAP,
       },
     ] as FieldDef[],
@@ -202,15 +247,18 @@ export const EMBED_FIELD_CATEGORIES = {
         key: "excludeMature",
         label: "Hide thumbnail on Mature works",
         description: "Never show a thumbnail for chapters belonging to a Mature-rated work.",
-        defaultEnabled: false,
       },
       {
         key: "excludeExplicit",
         label: "Hide thumbnail on Explicit works",
-        defaultEnabled: false,
         description: "Never show a thumbnail for chapters belonging to an Explicit-rated work.",
       },
     ] as FieldDef[],
+  },
+  // Inactivity auto-reset: default tab only.
+  "chapter-inactivity": {
+    title: "Inactivity",
+    fields: [] as FieldDef[],
   },
   series: {
     title: "Fields",
@@ -225,16 +273,23 @@ export const EMBED_FIELD_CATEGORIES = {
       {
         key: "notes",
         label: "Notes",
-        description: "The series' author notes, if any.",
-        maxLength: FIELD_VALUE_HARD_CAP,
+        description: "Adds a Notes tab with the series' author notes, paginated if it's long.",
+        maxLength: 3000,
+        maxLengthCap: 10000,
       },
       {
         key: "description",
         label: "Description",
-        description: "The series' description, if the author wrote one.",
-        maxLength: FIELD_VALUE_HARD_CAP,
+        description: "Adds a Description tab with the series' description, paginated if it's long.",
+        maxLength: 3000,
+        maxLengthCap: 10000,
       },
     ] as FieldDef[],
+  },
+  // Inactivity auto-reset: default tab only.
+  "series-inactivity": {
+    title: "Inactivity",
+    fields: [] as FieldDef[],
   },
   user: {
     title: "Fields",
@@ -257,6 +312,16 @@ export const EMBED_FIELD_CATEGORIES = {
       },
     ] as FieldDef[],
   },
+  "user-inactivity": {
+    title: "Inactivity",
+    fields: [
+      {
+        key: "resetToFirstPage",
+        label: "Reset to page 1 after inactivity",
+        description: "The original profile message jumps back to page 1 after 5 minutes with no clicks.",
+      },
+    ] as FieldDef[],
+  },
 } as const;
 
 export type EmbedFieldCategory = keyof typeof EMBED_FIELD_CATEGORIES;
@@ -271,23 +336,21 @@ export interface EmbedFieldGroup {
 // gets one button per category listed here.
 export const EMBED_FIELD_GROUPS: EmbedFieldGroup[] = [
   { key: "general", title: "General", categories: ["general", "ratings", "restrictions"] },
-  { key: "work", title: "Work", categories: ["work-stats", "work-tags", "work-summary", "gallery"] },
-  { key: "chapter", title: "Chapter", categories: ["chapter", "chapter-thumbnail"] },
-  { key: "series", title: "Series", categories: ["series"] },
-  { key: "user", title: "User Profile", categories: ["user"] },
+  {
+    key: "work",
+    title: "Work",
+    categories: ["work-stats", "work-tags", "work-summary", "gallery", "work-inactivity"],
+  },
+  {
+    key: "chapter",
+    title: "Chapter",
+    categories: ["chapter", "chapter-tags", "chapter-thumbnail", "chapter-inactivity"],
+  },
+  { key: "series", title: "Series", categories: ["series", "series-inactivity"] },
+  { key: "user", title: "User Profile", categories: ["user", "user-inactivity"] },
 ];
 
 // --- DB column mapping ---
-//
-// Every field in the catalog above lives as a real boolean column (plus an
-// optional paired int column for maxLength-configurable fields) in exactly
-// one table per category — never split across tables within a category,
-// which is what lets writeCategoryValues below pick one table per write.
-// Column names mostly follow "show"/"allow" + PascalCase(key), but a few
-// (general, gallery) don't, so this is spelled out explicitly rather than
-// derived by string transformation — a wrong guess here would silently
-// write to a nonexistent column and throw at write time, or (worse) match
-// nothing and silently no-op.
 type BundleTable = "guild" | "work" | "chapter" | "series" | "user";
 
 const CATEGORY_TABLE: Record<EmbedFieldCategory, BundleTable> = {
@@ -296,12 +359,17 @@ const CATEGORY_TABLE: Record<EmbedFieldCategory, BundleTable> = {
   "work-tags": "work",
   "work-summary": "work",
   gallery: "guild",
+  "work-inactivity": "guild",
   ratings: "guild",
   restrictions: "guild",
   chapter: "chapter",
+  "chapter-tags": "chapter",
   "chapter-thumbnail": "chapter",
+  "chapter-inactivity": "chapter",
   series: "series",
+  "series-inactivity": "series",
   user: "user",
+  "user-inactivity": "user",
 };
 
 interface FieldColumnMap {
@@ -311,10 +379,9 @@ interface FieldColumnMap {
 
 const FIELD_COLUMNS: Record<EmbedFieldCategory, Record<string, FieldColumnMap>> = {
   general: {
-    // deleteOriginalMessage predates this table and reuses the column name
-    // from main's original schema instead of duplicating it.
     deleteOriginalMessage: { column: "deleteOriginalLink" },
     legacyWorkEmbed: { column: "legacyWorkEmbed" },
+    outageAlerts: { column: "outageAlertsEnabled" },
   },
   "work-stats": {
     words: { column: "showWords" },
@@ -340,6 +407,9 @@ const FIELD_COLUMNS: Record<EmbedFieldCategory, Record<string, FieldColumnMap>> 
     enabled: { column: "galleryEnabled" },
     nsfwWarningMature: { column: "galleryNsfwWarningMature" },
     nsfwWarningExplicit: { column: "galleryNsfwWarningExplicit" },
+  },
+  "work-inactivity": {
+    galleryResetToFirstPage: { column: "galleryResetToFirstPage" },
   },
   ratings: {
     "rating-not-rated": { column: "allowRatingNotRated" },
@@ -367,11 +437,18 @@ const FIELD_COLUMNS: Record<EmbedFieldCategory, Record<string, FieldColumnMap>> 
     summary: { column: "showSummary", lengthColumn: "summaryMaxLength" },
     notes: { column: "showNotes", lengthColumn: "notesMaxLength" },
   },
+  "chapter-tags": {
+    fandoms: { column: "showFandoms", lengthColumn: "fandomsMaxLength" },
+    relationships: { column: "showRelationships", lengthColumn: "relationshipsMaxLength" },
+    characters: { column: "showCharacters", lengthColumn: "charactersMaxLength" },
+    tags: { column: "showTags", lengthColumn: "tagsMaxLength" },
+  },
   "chapter-thumbnail": {
     enabled: { column: "showThumbnail" },
     excludeMature: { column: "hideThumbnailOnMature" },
     excludeExplicit: { column: "hideThumbnailOnExplicit" },
   },
+  "chapter-inactivity": {},
   series: {
     authors: { column: "showAuthors" },
     complete: { column: "showComplete" },
@@ -383,6 +460,7 @@ const FIELD_COLUMNS: Record<EmbedFieldCategory, Record<string, FieldColumnMap>> 
     notes: { column: "showNotes", lengthColumn: "notesMaxLength" },
     description: { column: "showDescription", lengthColumn: "descriptionMaxLength" },
   },
+  "series-inactivity": {},
   user: {
     pseuds: { column: "showPseuds" },
     joined: { column: "showJoined" },
@@ -394,6 +472,9 @@ const FIELD_COLUMNS: Record<EmbedFieldCategory, Record<string, FieldColumnMap>> 
     bookmarks: { column: "showBookmarks" },
     gifts: { column: "showGifts" },
     bio: { column: "showBio", lengthColumn: "bioMaxLength" },
+  },
+  "user-inactivity": {
+    resetToFirstPage: { column: "resetToFirstPage" },
   },
 };
 
@@ -413,10 +494,6 @@ function bundleRow(bundle: GuildSettingsBundle, category: EmbedFieldCategory): R
   }
 }
 
-// Dynamic column names mean the update payload can't be typed against a
-// specific table's row shape here — writeCategoryValues is the one place
-// that bridges FIELD_COLUMNS' string column names into the strictly-typed
-// per-table update functions in settings.ts.
 async function writeCategoryValues(
   guildId: string,
   category: EmbedFieldCategory,
@@ -437,14 +514,6 @@ async function writeCategoryValues(
   }
 }
 
-// Fields default to enabled unless a guild has explicitly turned them off (or
-// the field itself opts out via defaultEnabled: false) — this way new fields
-// added to the catalog later show up for everyone without needing a
-// settings migration, while opt-in-only fields stay off until requested.
-//
-// Takes a pre-fetched bundle (see getGuildSettingsBundle) rather than a
-// guildId so building an embed with a dozen field checks costs one DB round
-// trip total, not one per check.
 export function isFieldEnabled(
   bundle: GuildSettingsBundle,
   category: EmbedFieldCategory,
@@ -590,6 +659,8 @@ export async function resetCategoryToDefaults(guildId: string, category: EmbedFi
     values[map.column] = field.defaultEnabled ?? true;
     if (map.lengthColumn) values[map.lengthColumn] = field.maxLength ?? FIELD_VALUE_HARD_CAP;
   }
+  // Skip categories with no FieldDefs (e.g. the -inactivity ones).
+  if (Object.keys(values).length === 0) return;
   await writeCategoryValues(guildId, category, values);
 }
 
@@ -600,6 +671,44 @@ export function getIgnoreChar(bundle: GuildSettingsBundle): string {
 export async function setIgnoreChar(guildId: string, ignoreChar: string): Promise<void> {
   const char = ignoreChar.trim().slice(0, 1);
   await updateGuildSettings(guildId, { ignoreChar: char || DEFAULT_IGNORE_CHAR });
+}
+
+// Inactivity auto-reset: default tab per embed type.
+export type WorkDefaultTab = "stats" | "tags" | "summary" | "none";
+export type ChapterDefaultTab = "stats" | "tags" | "summary" | "none";
+export type SeriesDefaultTab = "stats" | "notes" | "description" | "none";
+
+export function getWorkDefaultTab(bundle: GuildSettingsBundle): WorkDefaultTab {
+  return bundle.work?.defaultTab ?? "stats";
+}
+
+export async function setWorkDefaultTab(guildId: string, tab: WorkDefaultTab): Promise<void> {
+  await updateWorkFieldSettings(guildId, { defaultTab: tab });
+}
+
+export function getChapterDefaultTab(bundle: GuildSettingsBundle): ChapterDefaultTab {
+  return bundle.chapter?.defaultTab ?? "stats";
+}
+
+export async function setChapterDefaultTab(guildId: string, tab: ChapterDefaultTab): Promise<void> {
+  await updateChapterFieldSettings(guildId, { defaultTab: tab });
+}
+
+export function getSeriesDefaultTab(bundle: GuildSettingsBundle): SeriesDefaultTab {
+  return bundle.series?.defaultTab ?? "stats";
+}
+
+export async function setSeriesDefaultTab(guildId: string, tab: SeriesDefaultTab): Promise<void> {
+  await updateSeriesFieldSettings(guildId, { defaultTab: tab });
+}
+
+// /list's reset toggle — shown on the Series settings page.
+export function getListResetToFirstPage(bundle: GuildSettingsBundle): boolean {
+  return bundle.guild?.listResetToFirstPage ?? true;
+}
+
+export async function setListResetToFirstPage(guildId: string, enabled: boolean): Promise<void> {
+  await updateGuildSettings(guildId, { listResetToFirstPage: enabled });
 }
 
 // Flips a single field via a partial UPDATE on just its column — used to

--- a/utils/embeds/chapterEmbed.ts
+++ b/utils/embeds/chapterEmbed.ts
@@ -1,31 +1,47 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } from "discord.js";
+import type { ButtonInteraction, EmbedBuilder } from "discord.js";
 import { cachedGetWorkChapter, cachedGetWorkContent } from "../cache.ts";
 import { chapterDisplay, formatCompletionStatus, publishedDate, updatedAt } from "../statuses.ts";
 import { embedColor, ratingIcon } from "../ratings.ts";
 import { getWorkDetailsFromUrl, getWorkUrl } from "@fujocoded/ao3.js/urls";
 
 import { ao3Embed } from "../baseEmbed.ts";
+import { authError } from "../errors.ts";
 import { constructCreators } from "../creators.ts";
 import { countChapterWords } from "../words.ts";
-import { formatWarnings } from "../tags.ts";
+import {
+  formatCharacters,
+  formatFandoms,
+  formatRelationships,
+  formatTags,
+  formatWarnings,
+} from "../tags.ts";
 import { formatWorkSeries } from "../../utils/details.ts";
 import { htmlToMarkdown } from "../htmlToMarkdown.ts";
-import { getFieldMaxLength, getGuildSettingsBundle, isFieldEnabled } from "../embedFields.ts";
+import { getChapterDefaultTab, getFieldMaxLength, getGuildSettingsBundle, isFieldEnabled } from "../embedFields.ts";
+import type { ChapterDefaultTab } from "../embedFields.ts";
 import { extractImagesFromHtml, optimizeImageUrl } from "../images.ts";
+import { chunkTextMerged } from "../chunkText.ts";
+import { scheduleInactivityReset } from "../inactivityReset.ts";
 import { stripIndents } from "common-tags";
 import { truncateText } from "../truncate.ts";
 
-export const chapterEmbed = async (workURL: string, guildId?: string | null) => {
+type ChapterFieldEntry = { key: string; name: string; value: string; inline: boolean };
+type CacheKey = string | number;
+type ContentTabLabel = "Summary" | "Notes" | null;
+
+const CHUNK_LENGTH = 750;
+
+async function computeChapterFieldData(workURL: string, guildId?: string | null) {
   const { workId, chapterId } = getWorkDetailsFromUrl({ url: workURL });
   const work = await cachedGetWorkChapter(workId, chapterId);
 
-  if (work.locked) {
-    return work;
-  }
+  if (work.locked) return { locked: true as const };
 
   const content = await cachedGetWorkContent(workId, chapterId);
   const bundle = await getGuildSettingsBundle(guildId);
   const color = embedColor(work);
-	
+
   const creators =
     constructCreators(work.authors, work.authors?.[0]?.anonymous) || "Anonymous";
   const series = formatWorkSeries(work);
@@ -38,30 +54,29 @@ export const chapterEmbed = async (workURL: string, guildId?: string | null) => 
   const rating = ratingIcon(work) ?? "N/A";
   const warnings = formatWarnings(work) || "None";
 
-  // Always leads with "Chapter N" so it's unmistakable at a glance that this
-  // is a chapter embed, not a work embed — a custom chapter name (if any) is
-  // appended rather than replacing the "Chapter N" indicator.
+  // Chapter title: "Chapter N" or "Chapter N: Name".
   const chapterIndex = work.chapterInfo?.index ?? "?";
   const chapterTitle = work.chapterInfo?.name
     ? `Chapter ${chapterIndex}: ${work.chapterInfo.name}`
     : `Chapter ${chapterIndex}`;
 
-  const chapterSummary = truncateText(
-    htmlToMarkdown(work.chapterInfo?.summary) ?? "*This chapter does not have a summary.*",
-    getFieldMaxLength(bundle, "chapter", "summary"),
-  );
+  const rawSummary = htmlToMarkdown(work.chapterInfo?.summary);
+  const summaryText = rawSummary
+    ? truncateText(rawSummary, getFieldMaxLength(bundle, "chapter", "summary"))
+    : null;
 
   const noteParts = [
     content.startNotes && `**Beginning:**\n${htmlToMarkdown(content.startNotes)}`,
     content.endNotes && `**End:**\n${htmlToMarkdown(content.endNotes)}`,
   ].filter(Boolean);
-  const chapterNotes = noteParts.length
-    ? truncateText(noteParts.join("\n\n"), getFieldMaxLength(bundle, "chapter", "notes"))
+  const rawNotes = noteParts.length ? noteParts.join("\n\n") : null;
+  const notesText = rawNotes
+    ? truncateText(rawNotes, getFieldMaxLength(bundle, "chapter", "notes"))
     : null;
 
   const readFromBeginningUrl = getWorkUrl({ workId });
 
-	// TODO: Add collections to embed.
+  // TODO: Add collections to embed.
   const description = stripIndents`
     **${work.title}**
     by ${creators}
@@ -69,7 +84,7 @@ export const chapterEmbed = async (workURL: string, guildId?: string | null) => 
     [Read from the beginning](${readFromBeginningUrl})
   `;
 
-  const fields = [
+  const statsFields: ChapterFieldEntry[] = [
     { key: "words", name: "Words", value: wordCount, inline: true },
     { key: "chapters", name: "Chapters", value: chapterDisplay(work), inline: true },
     { key: "rating", name: "Rating", value: rating, inline: true },
@@ -77,30 +92,302 @@ export const chapterEmbed = async (workURL: string, guildId?: string | null) => 
     { key: "updated", name: "Updated", value: updatedDate, inline: true },
     { key: "status", name: "Status", value: status, inline: true },
     { key: "warnings", name: "Warnings", value: warnings, inline: false },
-    { key: "summary", name: "Summary", value: chapterSummary, inline: false },
-    ...(chapterNotes ? [{ key: "notes", name: "Notes", value: chapterNotes, inline: false }] : []),
   ].filter((f) => isFieldEnabled(bundle, "chapter", f.key));
 
-  // The title/URL point at this specific chapter (not the work's first
-  // chapter), so clicking through lands where the embed says it will.
-  const embed = ao3Embed(color)
-    .setTitle(chapterTitle)
-    .setURL(workURL)
-    .setDescription(description)
-    .addFields(fields.map(({ name, value, inline }) => ({ name, value, inline })));
+  // Tags tab — reuses the work's tag data.
+  const truncateTag = (key: string, s: string) =>
+    truncateText(s, getFieldMaxLength(bundle, "chapter-tags", key));
 
-  // Just the first embedded image as a small thumbnail — unlike the Work
-  // gallery, which fetches every image into its own paginated set of embeds.
-  // Its own settings category (not the general Fields checkbox group) so it
-  // can carry rating-based exclusions independent of the master toggle.
+  const tagsFields: ChapterFieldEntry[] = [
+    { key: "fandoms", name: "Fandoms", value: truncateTag("fandoms", formatFandoms(work) || "N/A"), inline: false },
+    {
+      key: "relationships",
+      name: "Relationships",
+      value: truncateTag("relationships", formatRelationships(work) || "N/A"),
+      inline: false,
+    },
+    {
+      key: "characters",
+      name: "Characters",
+      value: truncateTag("characters", formatCharacters(work) || "N/A"),
+      inline: false,
+    },
+    { key: "tags", name: "Additional Tags", value: truncateTag("tags", formatTags(work) || "N/A"), inline: false },
+  ].filter((f) => isFieldEnabled(bundle, "chapter-tags", f.key));
+
+  const summaryEnabled = !!summaryText && isFieldEnabled(bundle, "chapter", "summary");
+  const notesEnabled = !!notesText && isFieldEnabled(bundle, "chapter", "notes");
+
+  // Summary/Notes tab — Notes merges into Summary if both exist.
+  let contentText: string | null = null;
+  let contentTabLabel: ContentTabLabel = null;
+  if (summaryEnabled && summaryText) {
+    contentText = notesEnabled && notesText ? `${summaryText}\n\n**Notes**\n${notesText}` : summaryText;
+    contentTabLabel = "Summary";
+  } else if (notesEnabled && notesText) {
+    contentText = notesText;
+    contentTabLabel = "Notes";
+  }
+
+  // Thumbnail — first embedded image.
   const thumbnailExcludedByRating =
     (work.rating === "Mature" && isFieldEnabled(bundle, "chapter-thumbnail", "excludeMature")) ||
     (work.rating === "Explicit" && isFieldEnabled(bundle, "chapter-thumbnail", "excludeExplicit"));
 
+  let thumbnailUrl: string | undefined;
   if (isFieldEnabled(bundle, "chapter-thumbnail", "enabled") && !thumbnailExcludedByRating) {
     const [firstImage] = extractImagesFromHtml(content.content);
-    if (firstImage) embed.setThumbnail(optimizeImageUrl(firstImage));
+    if (firstImage) thumbnailUrl = optimizeImageUrl(firstImage);
   }
 
-  return embed;
+  return {
+    locked: false as const,
+    workId,
+    chapterId,
+    color,
+    workURL,
+    chapterTitle,
+    description,
+    statsFields,
+    tagsFields,
+    contentText,
+    contentTabLabel,
+    thumbnailUrl,
+  };
+}
+
+export interface ChapterEmbedPages {
+  pages: EmbedBuilder[];
+  tagsPageCount: number;
+  contentPageCount: number;
+  contentTabLabel: ContentTabLabel;
+}
+
+export async function buildChapterEmbedPages(
+  workURL: string,
+  guildId?: string | null,
+): Promise<ChapterEmbedPages | { locked: true }> {
+  const data = await computeChapterFieldData(workURL, guildId);
+  if (data.locked) return { locked: true };
+
+  const {
+    color,
+    workURL: url,
+    chapterTitle,
+    description,
+    statsFields,
+    tagsFields,
+    contentText,
+    contentTabLabel,
+    thumbnailUrl,
+  } = data;
+
+  const statsEmbed = ao3Embed(color)
+    .setTitle(chapterTitle)
+    .setURL(url)
+    .setDescription(description)
+    .addFields(statsFields.map(({ name, value, inline }) => ({ name, value, inline })));
+  if (thumbnailUrl) statsEmbed.setThumbnail(thumbnailUrl);
+
+  const pages: EmbedBuilder[] = [statsEmbed];
+
+  const tagsPageCount = tagsFields.length > 0 ? 1 : 0;
+  if (tagsPageCount > 0) {
+    pages.push(
+      ao3Embed(color)
+        .setTitle(chapterTitle)
+        .setURL(url)
+        .addFields(tagsFields.map(({ name, value, inline }) => ({ name, value, inline }))),
+    );
+  }
+
+  let contentPageCount = 0;
+  if (contentText) {
+    const chunks = chunkTextMerged(contentText, CHUNK_LENGTH);
+    contentPageCount = chunks.length;
+    for (const chunk of chunks) {
+      pages.push(ao3Embed(color).setTitle(chapterTitle).setURL(url).setDescription(chunk));
+    }
+  }
+
+  return { pages, tagsPageCount, contentPageCount, contentTabLabel };
+}
+
+export function buildChapterEmbedComponents(
+  ownerId: string,
+  page: number,
+  tagsPageCount: number,
+  contentPageCount: number,
+  contentTabLabel: ContentTabLabel,
+  workId: CacheKey,
+  chapterId: CacheKey,
+) {
+  const tagsStart = 1;
+  const contentStart = tagsStart + tagsPageCount;
+  const totalPages = contentStart + contentPageCount;
+
+  const onStats = page === 0;
+  const onTags = tagsPageCount > 0 && page >= tagsStart && page < contentStart;
+  const onContent = contentPageCount > 0 && page >= contentStart;
+
+  const tabButtons = [
+    new ButtonBuilder()
+      .setCustomId(`chapteremd-tab:${ownerId}:0:${workId}:${chapterId}`)
+      .setLabel("Stats")
+      .setStyle(onStats ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(onStats),
+  ];
+
+  // Tags tab — omitted if empty.
+  if (tagsPageCount > 0) {
+    tabButtons.push(
+      new ButtonBuilder()
+        .setCustomId(`chapteremd-tab:${ownerId}:${tagsStart}:${workId}:${chapterId}`)
+        .setLabel("Tags")
+        .setStyle(onTags ? ButtonStyle.Primary : ButtonStyle.Secondary)
+        .setDisabled(onTags),
+    );
+  }
+
+  if (contentPageCount > 0 && contentTabLabel) {
+    tabButtons.push(
+      new ButtonBuilder()
+        .setCustomId(`chapteremd-tab:${ownerId}:${contentStart}:${workId}:${chapterId}`)
+        .setLabel(contentTabLabel)
+        .setStyle(onContent ? ButtonStyle.Primary : ButtonStyle.Secondary)
+        .setDisabled(onContent),
+    );
+  }
+
+  const tabRow = new ActionRowBuilder<ButtonBuilder>().addComponents(tabButtons);
+
+  const navRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`chapteremd-nav:${ownerId}:${page - 1}:${workId}:${chapterId}`)
+      .setLabel("Previous")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(page <= 0),
+    new ButtonBuilder()
+      .setCustomId(`chapteremd-nav:${ownerId}:${page + 1}:${workId}:${chapterId}`)
+      .setLabel("Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(page >= totalPages - 1),
+  );
+
+  return [tabRow, navRow];
+}
+
+// Default tab resolver.
+function resolveChapterDefaultPage(
+  tagsPageCount: number,
+  contentPageCount: number,
+  defaultTab: ChapterDefaultTab,
+): number | null {
+  if (defaultTab === "none") return null;
+  const tagsStart = 1;
+  const contentStart = tagsStart + tagsPageCount;
+  if (defaultTab === "tags" && tagsPageCount > 0) return tagsStart;
+  if (defaultTab === "summary" && contentPageCount > 0) return contentStart;
+  return 0;
+}
+
+// Default-tab payload for the inactivity auto-reset.
+export async function buildChapterEmbedDefaultPayload(
+  workURL: string,
+  guildId: string | null | undefined,
+  ownerId: string,
+): Promise<{ embeds: EmbedBuilder[]; components: ReturnType<typeof buildChapterEmbedComponents> | [] } | null> {
+  const bundle = await getGuildSettingsBundle(guildId);
+  const defaultTab = getChapterDefaultTab(bundle);
+  if (defaultTab === "none") return null;
+
+  const result = await buildChapterEmbedPages(workURL, guildId);
+  if ("locked" in result) return null;
+
+  const page = resolveChapterDefaultPage(result.tagsPageCount, result.contentPageCount, defaultTab);
+  if (page === null) return null;
+
+  const { workId, chapterId } = getWorkDetailsFromUrl({ url: workURL });
+  return {
+    embeds: [result.pages[page]],
+    components:
+      result.pages.length > 1
+        ? buildChapterEmbedComponents(
+            ownerId,
+            page,
+            result.tagsPageCount,
+            result.contentPageCount,
+            result.contentTabLabel,
+            workId,
+            chapterId!,
+          )
+        : [],
+  };
+}
+
+export const handleChapterEmbedButtonInteraction = async (
+  interaction: ButtonInteraction,
+) => {
+  const parts = interaction.customId.split(":");
+  if (!parts[0].startsWith("chapteremd")) return false;
+
+  const [, ownerId, pageText, workId, chapterId] = parts;
+  const isOwner = interaction.user.id === ownerId;
+
+  // Non-owners get their own ephemeral copy.
+  if (isOwner) {
+    await interaction.deferUpdate();
+  } else {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  }
+
+  try {
+    const workURL = getWorkUrl({ workId, chapterId });
+    const result = await buildChapterEmbedPages(workURL, interaction.guildId);
+    if ("locked" in result) {
+      await interaction.editReply({
+        content: authError.content,
+        embeds: [],
+        components: [],
+      });
+      return true;
+    }
+
+    const page = Math.min(
+      Math.max(Number.parseInt(pageText, 10) || 0, 0),
+      result.pages.length - 1,
+    );
+    const componentOwnerId = isOwner ? ownerId : interaction.user.id;
+    await interaction.editReply({
+      embeds: [result.pages[page]],
+      components:
+        result.pages.length > 1
+          ? buildChapterEmbedComponents(
+              componentOwnerId,
+              page,
+              result.tagsPageCount,
+              result.contentPageCount,
+              result.contentTabLabel,
+              workId,
+              chapterId,
+            )
+          : [],
+    });
+
+    if (isOwner) {
+      scheduleInactivityReset(interaction.message, () =>
+        buildChapterEmbedDefaultPayload(workURL, interaction.guildId, ownerId),
+      );
+    }
+  } catch (error) {
+    console.error(`Failed to refresh chapter embed for ${workId}/${chapterId}`, error);
+    await interaction
+      .editReply({
+        content: "⚠️ Something went wrong fetching that from AO3.",
+        embeds: [],
+        components: [],
+      })
+      .catch(() => {});
+  }
+  return true;
 };

--- a/utils/embeds/seriesEmbed.ts
+++ b/utils/embeds/seriesEmbed.ts
@@ -1,14 +1,24 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } from "discord.js";
+import type { ButtonInteraction, EmbedBuilder } from "discord.js";
 import { formatCompletionStatus, startedDate, updatedAt } from "../statuses.ts";
-import { getFieldMaxLength, getGuildSettingsBundle, isFieldEnabled } from "../embedFields.ts";
+import { getFieldMaxLength, getGuildSettingsBundle, getSeriesDefaultTab, isFieldEnabled } from "../embedFields.ts";
+import type { SeriesDefaultTab } from "../embedFields.ts";
 
 import { ao3Embed } from "../baseEmbed.ts";
 import { cachedGetSeries } from "../cache.ts";
+import { chunkTextMerged } from "../chunkText.ts";
 import { constructCreators } from "../creators.ts";
 import { getSeriesIdFromUrl } from "../urls.ts";
 import { htmlToMarkdown } from "../htmlToMarkdown.ts";
+import { scheduleInactivityReset } from "../inactivityReset.ts";
 import { truncateText } from "../truncate.ts";
 
-export const seriesEmbed = async (seriesURL: string, guildId?: string | null) => {
+type SeriesFieldEntry = { key: string; name: string; value: string; inline: boolean };
+type CacheKey = string | number;
+
+const CHUNK_LENGTH = 750;
+
+async function computeSeriesFieldData(seriesURL: string, guildId?: string | null) {
   const seriesId = getSeriesIdFromUrl(seriesURL);
   const series = await cachedGetSeries(seriesId);
   const bundle = await getGuildSettingsBundle(guildId);
@@ -16,14 +26,14 @@ export const seriesEmbed = async (seriesURL: string, guildId?: string | null) =>
   const creators =
     constructCreators(series.authors, series.authors?.[0]?.anonymous) ||
     "Anonymous";
-  const notes = truncateText(
-    htmlToMarkdown(series.notes) ?? "*This series does not have notes.*",
-    getFieldMaxLength(bundle, "series", "notes"),
-  );
-  const seriesDescription = truncateText(
-    htmlToMarkdown(series.description) ?? "*This series does not have a description.*",
-    getFieldMaxLength(bundle, "series", "description"),
-  );
+
+  const rawNotes = htmlToMarkdown(series.notes);
+  const notesText = rawNotes ? truncateText(rawNotes, getFieldMaxLength(bundle, "series", "notes")) : null;
+
+  const rawDescription = htmlToMarkdown(series.description);
+  const descriptionText = rawDescription
+    ? truncateText(rawDescription, getFieldMaxLength(bundle, "series", "description"))
+    : null;
 
   const descriptionLines = [
     { key: "authors", line: `**Authors:** ${creators}` },
@@ -32,20 +42,237 @@ export const seriesEmbed = async (seriesURL: string, guildId?: string | null) =>
     .map((f) => f.line)
     .join("\n");
 
-  const fields = [
+  const statsFields: SeriesFieldEntry[] = [
     { key: "started", name: "Started", value: startedDate(series), inline: true },
     { key: "updated", name: "Updated", value: updatedAt(series), inline: true },
     { key: "complete", name: "Status", value: `${formatCompletionStatus(series)}`, inline: true },
-		{ key: "workCount", name: "Works", value: `${series.workCount.toLocaleString()}`,  inline: true  },
-    { key: "wordCount", name: "Total Words", value: `${series.words.toLocaleString()}`, inline: true  },
-		{ key: "bookmarks", name: "Bookmarks", value: `${Number.isFinite(series.bookmarks) ? series.bookmarks.toLocaleString() : "0"}`, inline: true },
-    { key: "notes", name: "Notes", value: notes, inline: false },
-    { key: "description", name: "Description", value: seriesDescription, inline: false },
+    { key: "workCount", name: "Works", value: `${series.workCount.toLocaleString()}`, inline: true },
+    { key: "wordCount", name: "Total Words", value: `${series.words.toLocaleString()}`, inline: true },
+    {
+      key: "bookmarks",
+      name: "Bookmarks",
+      value: `${Number.isFinite(series.bookmarks) ? series.bookmarks.toLocaleString() : "0"}`,
+      inline: true,
+    },
   ].filter((f) => isFieldEnabled(bundle, "series", f.key));
 
-  const embed = ao3Embed().setTitle(series.name).setURL(seriesURL);
-  if (descriptionLines) embed.setDescription(descriptionLines);
-  embed.addFields(fields.map(({ name, value, inline }) => ({ name, value, inline })));
+  const notesEnabled = !!notesText && isFieldEnabled(bundle, "series", "notes");
+  const descriptionEnabled = !!descriptionText && isFieldEnabled(bundle, "series", "description");
 
-  return embed;
+  return {
+    seriesId,
+    seriesName: series.name,
+    seriesURL,
+    descriptionLines,
+    statsFields,
+    notesText,
+    notesEnabled,
+    descriptionText,
+    descriptionEnabled,
+  };
+}
+
+export interface SeriesEmbedPages {
+  pages: EmbedBuilder[];
+  notesPageCount: number;
+  descriptionPageCount: number;
+}
+
+export async function buildSeriesEmbedPages(
+  seriesURL: string,
+  guildId?: string | null,
+): Promise<SeriesEmbedPages> {
+  const {
+    seriesName,
+    seriesURL: url,
+    descriptionLines,
+    statsFields,
+    notesText,
+    notesEnabled,
+    descriptionText,
+    descriptionEnabled,
+  } = await computeSeriesFieldData(seriesURL, guildId);
+
+  const statsEmbed = ao3Embed().setTitle(seriesName).setURL(url);
+  if (descriptionLines) statsEmbed.setDescription(descriptionLines);
+  statsEmbed.addFields(statsFields.map(({ name, value, inline }) => ({ name, value, inline })));
+
+  const pages: EmbedBuilder[] = [statsEmbed];
+
+  let notesPageCount = 0;
+  if (notesEnabled && notesText) {
+    const chunks = chunkTextMerged(notesText, CHUNK_LENGTH);
+    notesPageCount = chunks.length;
+    for (const chunk of chunks) {
+      pages.push(ao3Embed().setTitle(seriesName).setURL(url).setDescription(chunk));
+    }
+  }
+
+  let descriptionPageCount = 0;
+  if (descriptionEnabled && descriptionText) {
+    const chunks = chunkTextMerged(descriptionText, CHUNK_LENGTH);
+    descriptionPageCount = chunks.length;
+    for (const chunk of chunks) {
+      pages.push(ao3Embed().setTitle(seriesName).setURL(url).setDescription(chunk));
+    }
+  }
+
+  return { pages, notesPageCount, descriptionPageCount };
+}
+
+export function buildSeriesEmbedComponents(
+  ownerId: string,
+  page: number,
+  notesPageCount: number,
+  descriptionPageCount: number,
+  seriesId: CacheKey,
+) {
+  const notesStart = 1;
+  const descriptionStart = notesStart + notesPageCount;
+  const totalPages = descriptionStart + descriptionPageCount;
+
+  const onStats = page === 0;
+  const onNotes = notesPageCount > 0 && page >= notesStart && page < descriptionStart;
+  const onDescription = descriptionPageCount > 0 && page >= descriptionStart;
+
+  const tabButtons = [
+    new ButtonBuilder()
+      .setCustomId(`seriesemd-tab:${ownerId}:0:${seriesId}`)
+      .setLabel("Stats")
+      .setStyle(onStats ? ButtonStyle.Primary : ButtonStyle.Secondary)
+      .setDisabled(onStats),
+  ];
+
+  // Notes/Description tabs — omitted if empty.
+  if (notesPageCount > 0) {
+    tabButtons.push(
+      new ButtonBuilder()
+        .setCustomId(`seriesemd-tab:${ownerId}:${notesStart}:${seriesId}`)
+        .setLabel("Notes")
+        .setStyle(onNotes ? ButtonStyle.Primary : ButtonStyle.Secondary)
+        .setDisabled(onNotes),
+    );
+  }
+
+  if (descriptionPageCount > 0) {
+    tabButtons.push(
+      new ButtonBuilder()
+        .setCustomId(`seriesemd-tab:${ownerId}:${descriptionStart}:${seriesId}`)
+        .setLabel("Description")
+        .setStyle(onDescription ? ButtonStyle.Primary : ButtonStyle.Secondary)
+        .setDisabled(onDescription),
+    );
+  }
+
+  const tabRow = new ActionRowBuilder<ButtonBuilder>().addComponents(tabButtons);
+
+  const navRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`seriesemd-nav:${ownerId}:${page - 1}:${seriesId}`)
+      .setLabel("Previous")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(page <= 0),
+    new ButtonBuilder()
+      .setCustomId(`seriesemd-nav:${ownerId}:${page + 1}:${seriesId}`)
+      .setLabel("Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(page >= totalPages - 1),
+  );
+
+  return [tabRow, navRow];
+}
+
+// Default tab resolver.
+function resolveSeriesDefaultPage(
+  notesPageCount: number,
+  descriptionPageCount: number,
+  defaultTab: SeriesDefaultTab,
+): number | null {
+  if (defaultTab === "none") return null;
+  const notesStart = 1;
+  const descriptionStart = notesStart + notesPageCount;
+  if (defaultTab === "notes" && notesPageCount > 0) return notesStart;
+  if (defaultTab === "description" && descriptionPageCount > 0) return descriptionStart;
+  return 0;
+}
+
+// Default-tab payload for the inactivity auto-reset.
+export async function buildSeriesEmbedDefaultPayload(
+  seriesURL: string,
+  guildId: string | null | undefined,
+  ownerId: string,
+): Promise<{ embeds: EmbedBuilder[]; components: ReturnType<typeof buildSeriesEmbedComponents> | [] } | null> {
+  const bundle = await getGuildSettingsBundle(guildId);
+  const defaultTab = getSeriesDefaultTab(bundle);
+  if (defaultTab === "none") return null;
+
+  const result = await buildSeriesEmbedPages(seriesURL, guildId);
+  const page = resolveSeriesDefaultPage(result.notesPageCount, result.descriptionPageCount, defaultTab);
+  if (page === null) return null;
+
+  const seriesId = getSeriesIdFromUrl(seriesURL);
+  return {
+    embeds: [result.pages[page]],
+    components:
+      result.pages.length > 1
+        ? buildSeriesEmbedComponents(ownerId, page, result.notesPageCount, result.descriptionPageCount, seriesId)
+        : [],
+  };
+}
+
+export const handleSeriesEmbedButtonInteraction = async (
+  interaction: ButtonInteraction,
+) => {
+  const parts = interaction.customId.split(":");
+  if (!parts[0].startsWith("seriesemd")) return false;
+
+  const [, ownerId, pageText, seriesId] = parts;
+  const isOwner = interaction.user.id === ownerId;
+
+  // Non-owners get their own ephemeral copy.
+  if (isOwner) {
+    await interaction.deferUpdate();
+  } else {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  }
+
+  try {
+    const seriesURL = `https://archiveofourown.org/series/${seriesId}`;
+    const result = await buildSeriesEmbedPages(seriesURL, interaction.guildId);
+
+    const page = Math.min(
+      Math.max(Number.parseInt(pageText, 10) || 0, 0),
+      result.pages.length - 1,
+    );
+    const componentOwnerId = isOwner ? ownerId : interaction.user.id;
+    await interaction.editReply({
+      embeds: [result.pages[page]],
+      components:
+        result.pages.length > 1
+          ? buildSeriesEmbedComponents(
+              componentOwnerId,
+              page,
+              result.notesPageCount,
+              result.descriptionPageCount,
+              seriesId,
+            )
+          : [],
+    });
+
+    if (isOwner) {
+      scheduleInactivityReset(interaction.message, () =>
+        buildSeriesEmbedDefaultPayload(seriesURL, interaction.guildId, ownerId),
+      );
+    }
+  } catch (error) {
+    console.error(`Failed to refresh series embed for ${seriesId}`, error);
+    await interaction
+      .editReply({
+        content: "⚠️ Something went wrong fetching that from AO3.",
+        embeds: [],
+        components: [],
+      })
+      .catch(() => {});
+  }
+  return true;
 };

--- a/utils/embeds/userEmbed.ts
+++ b/utils/embeds/userEmbed.ts
@@ -6,12 +6,19 @@ import { ao3Embed } from "../baseEmbed.ts";
 import { cachedGetUser } from "../cache.ts";
 import { chunkText } from "../chunkText.ts";
 import { htmlToMarkdown } from "../htmlToMarkdown.ts";
+import { scheduleInactivityReset } from "../inactivityReset.ts";
 import { truncateText } from "../truncate.ts";
 
 const BIO_PAGE_LENGTH = 750;
 const BIO_INLINE_THRESHOLD = 300;
 const BIO_TRAILING_MERGE_THRESHOLD = 350;
 const MAX_HR_PER_PAGE = 2;
+const AO3_BASE_URL = "https://archiveofourown.org";
+
+// Resolves AO3's relative default-avatar path to an absolute URL.
+function resolveIconUrl(icon: string | null | undefined): string | null {
+  return icon ? new URL(icon, AO3_BASE_URL).href : null;
+}
 
 function padInlineRow(embed: EmbedBuilder, fieldCount: number) {
   const padding = (3 - (fieldCount % 3)) % 3;
@@ -114,7 +121,7 @@ export async function buildUserEmbedPages(
   const profilePage = ao3Embed()
     .setTitle(username)
     .setURL(userURL)
-    .setThumbnail(user.icon)
+    .setThumbnail(resolveIconUrl(user.icon))
     .setDescription(header);
 
   if (enabled("pseuds")) {
@@ -188,7 +195,7 @@ export async function buildUserEmbedPages(
     ao3Embed()
       .setTitle(username)
       .setURL(userURL)
-      .setThumbnail(user.icon)
+      .setThumbnail(resolveIconUrl(user.icon))
       .setDescription(chunk),
   );
 
@@ -215,6 +222,22 @@ export function buildUserEmbedComponents(
         .setDisabled(page >= pageCount - 1),
     ),
   ];
+}
+
+// Default-page payload for the inactivity auto-reset.
+export async function buildUserEmbedDefaultPayload(
+  username: string,
+  guildId: string | null | undefined,
+  ownerId: string,
+): Promise<{ embeds: EmbedBuilder[]; components: ReturnType<typeof buildUserEmbedComponents> | [] } | null> {
+  const bundle = await getGuildSettingsBundle(guildId);
+  if (!isFieldEnabled(bundle, "user-inactivity", "resetToFirstPage")) return null;
+
+  const pages = await buildUserEmbedPages(username, guildId);
+  return {
+    embeds: [pages[0]],
+    components: pages.length > 1 ? buildUserEmbedComponents(ownerId, 0, pages.length, username) : [],
+  };
 }
 
 export const handleUserEmbedButtonInteraction = async (
@@ -244,13 +267,17 @@ export const handleUserEmbedButtonInteraction = async (
     const componentOwnerId = isOwner ? ownerId : interaction.user.id;
     await interaction.editReply({
       embeds: [pages[page]],
-      components: buildUserEmbedComponents(
-        componentOwnerId,
-        page,
-        pages.length,
-        username,
-      ),
+      components:
+        pages.length > 1
+          ? buildUserEmbedComponents(componentOwnerId, page, pages.length, username)
+          : [],
     });
+
+    if (isOwner) {
+      scheduleInactivityReset(interaction.message, () =>
+        buildUserEmbedDefaultPayload(username, interaction.guildId, ownerId),
+      );
+    }
   } catch (error) {
     console.error(`Failed to refresh user embed for ${username}`, error);
     await interaction

--- a/utils/embeds/worksEmbed.ts
+++ b/utils/embeds/worksEmbed.ts
@@ -4,8 +4,11 @@ import {
   FIELD_VALUE_HARD_CAP,
   getFieldMaxLength,
   getGuildSettingsBundle,
+  getWorkDefaultTab,
   isFieldEnabled,
 } from "../embedFields.ts";
+import type { WorkDefaultTab } from "../embedFields.ts";
+import { scheduleInactivityReset } from "../inactivityReset.ts";
 import {
   chapterDisplay,
   formatCompletionStatus,
@@ -27,7 +30,7 @@ import { getWorkDetailsFromUrl, getWorkUrl } from "@fujocoded/ao3.js/urls";
 import { ao3Embed } from "../baseEmbed.ts";
 import { authError } from "../errors.ts";
 import { cachedGetWork } from "../cache.ts";
-import { chunkText } from "../chunkText.ts";
+import { chunkTextMerged } from "../chunkText.ts";
 import { constructCreators } from "../creators.ts";
 import { truncateText } from "../truncate.ts";
 
@@ -133,12 +136,7 @@ export async function buildWorkEmbedPages(
 
   // Page 3+: summary chunked at 750 chars
   if (summaryEnabled) {
-    const chunks = chunkText(summaryText, 750);
-    // Merge a short trailing chunk (< 250 chars) into the previous page
-    if (chunks.length >= 2 && chunks[chunks.length - 1].length < 250) {
-      const last = chunks.pop()!;
-      chunks[chunks.length - 1] += "\n" + last;
-    }
+    const chunks = chunkTextMerged(summaryText, 750);
     for (const chunk of chunks) {
       pages.push(
         ao3Embed(color)
@@ -239,6 +237,37 @@ export function buildWorkEmbedComponents(
   return [tabRow, navRow];
 }
 
+// Default tab resolver.
+function resolveWorkDefaultPage(pageCount: number, defaultTab: WorkDefaultTab): number | null {
+  if (defaultTab === "none") return null;
+  if (defaultTab === "tags") return 1;
+  if (defaultTab === "summary") return pageCount > 2 ? 2 : 0;
+  return 0;
+}
+
+// Default-tab payload for the inactivity auto-reset.
+export async function buildWorkEmbedDefaultPayload(
+  workURL: string,
+  guildId: string | null | undefined,
+  ownerId: string,
+): Promise<{ embeds: EmbedBuilder[]; components: ReturnType<typeof buildWorkEmbedComponents> | [] } | null> {
+  const bundle = await getGuildSettingsBundle(guildId);
+  const defaultTab = getWorkDefaultTab(bundle);
+  if (defaultTab === "none") return null;
+
+  const result = await buildWorkEmbedPages(workURL, guildId);
+  if ("locked" in result) return null;
+
+  const page = resolveWorkDefaultPage(result.length, defaultTab);
+  if (page === null) return null;
+
+  const workId = getWorkDetailsFromUrl({ url: workURL }).workId;
+  return {
+    embeds: [result[page]],
+    components: result.length > 1 ? buildWorkEmbedComponents(ownerId, page, result.length, workId) : [],
+  };
+}
+
 export const handleWorkEmbedButtonInteraction = async (
   interaction: ButtonInteraction,
 ) => {
@@ -280,6 +309,12 @@ export const handleWorkEmbedButtonInteraction = async (
           ? buildWorkEmbedComponents(componentOwnerId, page, result.length, workId)
           : [],
     });
+
+    if (isOwner) {
+      scheduleInactivityReset(interaction.message, () =>
+        buildWorkEmbedDefaultPayload(workURL, interaction.guildId, ownerId),
+      );
+    }
   } catch (error) {
     console.error(`Failed to refresh work embed for ${workId}`, error);
     await interaction

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -10,9 +10,10 @@ import {
 import { getWorkUrl } from "@fujocoded/ao3.js/urls";
 
 import { ao3Embed } from "./baseEmbed.ts";
-import { Cache, cachedGetWork } from "./cache.ts";
+import { Cache, cachedFetchText, cachedGetWork } from "./cache.ts";
 import { embedColor } from "./ratings.ts";
-import { getGuildSettingsBundle, shouldShowNsfwWarning } from "./embedFields.ts";
+import { getGuildSettingsBundle, isFieldEnabled, shouldShowNsfwWarning } from "./embedFields.ts";
+import { scheduleInactivityReset } from "./inactivityReset.ts";
 
 import type {
   ButtonInteraction,
@@ -24,11 +25,10 @@ type CacheKey = string | number;
 
 const IMAGES_PER_PAGE = 4;
 const HOUR_MS = 60 * 60 * 1000;
+const VIEW_ADULT_COOKIE = "view_adult=true;";
 
 // Rewrites known image hosts' URLs to smaller variants before handing them
-// to Discord, so its embed-image proxy has less to fetch/render — this is
-// what actually determines how fast a page "appears" once the bot itself
-// has responded (the bot's own lookup is cache-instant after the first load).
+// to Discord, so its embed-image proxy has less to fetch/render
 export function optimizeImageUrl(src: string): string {
   try {
     const url = new URL(src);
@@ -77,15 +77,11 @@ export function extractImagesFromHtml(html: string): string[] {
     .filter((src) => src.startsWith("http://") || src.startsWith("https://"));
 }
 
-// Fetches the full work in one request using AO3's view_full_work param
-// instead of one request per chapter, then caches the extracted image URLs.
 async function fetchWorkImages(workId: CacheKey): Promise<string[]> {
   return workImagesCache.getOrSet(workId, async () => {
     const url = `${getWorkUrl({ workId })}?view_full_work=true`;
-    const response = await fetch(url, {
-      headers: { Cookie: "view_adult=true;" },
-    });
-    return extractImagesFromHtml(await response.text());
+    const html = await cachedFetchText(url, VIEW_ADULT_COOKIE);
+    return extractImagesFromHtml(html);
   });
 }
 
@@ -212,19 +208,47 @@ export function buildWorkGalleryComponents(
   return rows;
 }
 
-// Shared by the Prev/Next buttons and the page-jump select menu — both just
-// need to know which page to render next.
+export async function buildGalleryDefaultPayload(
+  workId: CacheKey,
+  guildId: string | null | undefined,
+  ownerId: string,
+): Promise<{ embeds: EmbedBuilder[]; files: AttachmentBuilder[]; components: ReturnType<typeof buildWorkGalleryComponents> | [] } | null> {
+  const bundle = await getGuildSettingsBundle(guildId);
+  if (!isFieldEnabled(bundle, "work-inactivity", "galleryResetToFirstPage")) return null;
+
+  const work = await cachedGetWork(workId);
+  const nsfwWarning = work.locked ? false : shouldShowNsfwWarning(bundle, work.rating, work.locked);
+
+  const workURL = getWorkUrl({ workId });
+  const result = await buildWorkGalleryPage(workId, workURL, 0, { nsfwWarning });
+  if (!result) return null;
+
+  return {
+    embeds: result.page.embeds,
+    files: result.page.files,
+    components: result.totalPages > 1 ? buildWorkGalleryComponents(ownerId, 0, result.totalPages, workId) : [],
+  };
+}
+
 async function renderGalleryPage(
   interaction: ButtonInteraction | StringSelectMenuInteraction,
   ownerId: string,
   workId: CacheKey,
   currentPage: number,
 ): Promise<void> {
-  await interaction.deferUpdate();
+  const isOwner = interaction.user.id === ownerId;
+  const componentOwnerId = isOwner ? ownerId : interaction.user.id;
+
+  // Non-owners get their own ephemeral copy.
+  if (isOwner) {
+    await interaction.deferUpdate();
+  } else {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  }
 
   await interaction.editReply({
     components: buildWorkGalleryComponents(
-      ownerId,
+      componentOwnerId,
       currentPage,
       currentPage + 2,
       workId,
@@ -260,9 +284,15 @@ async function renderGalleryPage(
     files: result.page.files,
     components:
       result.totalPages > 1
-        ? buildWorkGalleryComponents(ownerId, currentPage, result.totalPages, workId)
+        ? buildWorkGalleryComponents(componentOwnerId, currentPage, result.totalPages, workId)
         : [],
   });
+
+  if (isOwner) {
+    scheduleInactivityReset(interaction.message, () =>
+      buildGalleryDefaultPayload(workId, interaction.guildId, ownerId),
+    );
+  }
 }
 
 export const handleWorkGalleryButtonInteraction = async (
@@ -272,15 +302,6 @@ export const handleWorkGalleryButtonInteraction = async (
   if (parts[0] !== "gallery") return false;
 
   const [, ownerId, pageText, workId] = parts;
-  if (interaction.user.id !== ownerId) {
-    await interaction.reply({
-      content:
-        "This gallery belongs to someone else. Post the link yourself to get your own copy.",
-      flags: MessageFlags.Ephemeral,
-    });
-    return true;
-  }
-
   const currentPage = Number.parseInt(pageText, 10) || 0;
   await renderGalleryPage(interaction, ownerId, workId, currentPage);
   return true;
@@ -293,15 +314,6 @@ export const handleWorkGallerySelectInteraction = async (
   if (parts[0] !== "gallery-select") return false;
 
   const [, ownerId, workId] = parts;
-  if (interaction.user.id !== ownerId) {
-    await interaction.reply({
-      content:
-        "This gallery belongs to someone else. Post the link yourself to get your own copy.",
-      flags: MessageFlags.Ephemeral,
-    });
-    return true;
-  }
-
   const currentPage = Number.parseInt(interaction.values[0], 10) || 0;
   await renderGalleryPage(interaction, ownerId, workId, currentPage);
   return true;

--- a/utils/inactivityReset.ts
+++ b/utils/inactivityReset.ts
@@ -1,0 +1,37 @@
+// Inactivity auto-reset: resets a paginated message to its default page
+// after 5 minutes with no clicks. Owner messages only.
+const RESET_DELAY_MS = 5 * 60 * 1000;
+
+interface EditablePayload {
+  embeds: any[];
+  components: any[];
+  files?: any[];
+}
+
+interface EditableMessage {
+  id: string;
+  edit: (payload: any) => Promise<unknown>;
+}
+
+const pendingResets = new Map<string, NodeJS.Timeout>();
+
+export function scheduleInactivityReset(
+  message: EditableMessage,
+  buildDefaultPayload: () => Promise<EditablePayload | null>,
+): void {
+  const existing = pendingResets.get(message.id);
+  if (existing) clearTimeout(existing);
+
+  const timer = setTimeout(async () => {
+    pendingResets.delete(message.id);
+    try {
+      const payload = await buildDefaultPayload();
+      if (!payload) return;
+      await message.edit(payload);
+    } catch (error) {
+      console.error(`Failed to reset message ${message.id} to its default page`, error);
+    }
+  }, RESET_DELAY_MS);
+
+  pendingResets.set(message.id, timer);
+}

--- a/utils/otwStatus.ts
+++ b/utils/otwStatus.ts
@@ -1,0 +1,189 @@
+import type { Client, EmbedBuilder } from "discord.js";
+
+import { ao3Embed } from "./baseEmbed.ts";
+import { getGuildsWithOutageAlertsEnabled } from "./settings.ts";
+
+// AO3 outage monitor — polls otwstatus.org's public Statuspage API.
+const INCIDENTS_API_URL = "https://www.otwstatus.org/api/v2/incidents.json";
+const COMPONENTS_API_URL = "https://www.otwstatus.org/api/v2/components.json";
+const AO3_COMPONENT_NAME = "Archive of Our Own";
+const POLL_INTERVAL_MS = 2 * 60 * 1000;
+
+const GENERIC_STATUS_LABELS: Record<string, string> = {
+  operational: "Operational",
+  degraded_performance: "Degraded Performance",
+  partial_outage: "Partial Outage",
+  major_outage: "Major Outage",
+  under_maintenance: "Under Maintenance",
+};
+
+const GENERIC_STATUS_COLORS: Record<string, number> = {
+  operational: 0x2ecc71,
+  degraded_performance: 0xf1c40f,
+  partial_outage: 0xe67e22,
+  major_outage: 0xe74c3c,
+  under_maintenance: 0x3498db,
+};
+
+const UPDATE_STATUS_LABELS: Record<string, string> = {
+  investigating: "Investigating",
+  identified: "Identified",
+  monitoring: "Monitoring",
+  resolved: "Resolved",
+  postmortem: "Postmortem",
+};
+
+const UPDATE_STATUS_COLORS: Record<string, number> = {
+  investigating: 0xe74c3c,
+  identified: 0xe67e22,
+  monitoring: 0xf1c40f,
+  resolved: 0x2ecc71,
+  postmortem: 0x3498db,
+};
+
+interface AffectedComponent {
+  name: string;
+}
+
+interface IncidentUpdate {
+  id: string;
+  status: string;
+  body: string;
+  affected_components?: AffectedComponent[];
+}
+
+interface Incident {
+  id: string;
+  name: string;
+  shortlink: string;
+  components: AffectedComponent[];
+  incident_updates: IncidentUpdate[];
+}
+
+async function fetchAo3Incidents(): Promise<Incident[] | null> {
+  try {
+    const response = await fetch(INCIDENTS_API_URL);
+    if (!response.ok) return null;
+    const data = (await response.json()) as { incidents: Incident[] };
+    return data.incidents.filter((incident) =>
+      incident.components.some((component) => component.name === AO3_COMPONENT_NAME),
+    );
+  } catch (error) {
+    console.error("Failed to fetch AO3 incidents from otwstatus.org", error);
+    return null;
+  }
+}
+
+function buildIncidentUpdateEmbed(incident: Incident, update: IncidentUpdate): EmbedBuilder {
+  const label = UPDATE_STATUS_LABELS[update.status] ?? update.status;
+  const color = UPDATE_STATUS_COLORS[update.status] ?? 0x2f3136;
+  const isResolved = update.status === "resolved";
+
+  return ao3Embed(color)
+    .setTitle(`${isResolved ? "✅" : "⚠️"} ${incident.name} — ${label}`)
+    .setURL(incident.shortlink)
+    .setDescription(update.body);
+}
+
+async function fetchAo3ComponentStatus(): Promise<string | null> {
+  try {
+    const response = await fetch(COMPONENTS_API_URL);
+    if (!response.ok) return null;
+    const data = (await response.json()) as { components: { name: string; status: string }[] };
+    return data.components.find((component) => component.name === AO3_COMPONENT_NAME)?.status ?? null;
+  } catch (error) {
+    console.error("Failed to fetch AO3 component status from otwstatus.org", error);
+    return null;
+  }
+}
+
+// Fallback notice for a status change with no published incident.
+function buildGenericStatusEmbed(status: string): EmbedBuilder {
+  const label = GENERIC_STATUS_LABELS[status] ?? status;
+  const color = GENERIC_STATUS_COLORS[status] ?? 0x2f3136;
+  const isRecovered = status === "operational";
+
+  return ao3Embed(color)
+    .setTitle(isRecovered ? "✅ AO3 is back to normal" : `⚠️ AO3 status: ${label}`)
+    .setURL("https://www.otwstatus.org/")
+    .setDescription(
+      (isRecovered
+        ? "Archive of Our Own's status has returned to **Operational**."
+        : `Archive of Our Own's status changed to **${label}**.`) +
+        "\n\n*No incident was published for this change — this is a fallback notice.*",
+    );
+}
+
+// Already-posted incident update IDs, per incident.
+const postedUpdateIds = new Map<string, Set<string>>();
+let lastKnownComponentStatus: string | null = null;
+let hasSeededInitialState = false;
+
+async function pollAndNotify(client: Client): Promise<void> {
+  const [incidents, componentStatus] = await Promise.all([fetchAo3Incidents(), fetchAo3ComponentStatus()]);
+  if (!incidents || !componentStatus) return;
+
+  if (!hasSeededInitialState) {
+    for (const incident of incidents) {
+      postedUpdateIds.set(incident.id, new Set(incident.incident_updates.map((update) => update.id)));
+    }
+    lastKnownComponentStatus = componentStatus;
+    hasSeededInitialState = true;
+    return;
+  }
+
+  const newUpdates: { incident: Incident; update: IncidentUpdate }[] = [];
+
+  for (const incident of incidents) {
+    const seen = postedUpdateIds.get(incident.id) ?? new Set<string>();
+    // Post oldest-to-newest.
+    for (const update of [...incident.incident_updates].reverse()) {
+      if (seen.has(update.id)) continue;
+      seen.add(update.id);
+      newUpdates.push({ incident, update });
+    }
+    postedUpdateIds.set(incident.id, seen);
+  }
+
+  // Status changed but no incident update covers it — use the fallback.
+  const statusChangedWithoutIncident = componentStatus !== lastKnownComponentStatus && newUpdates.length === 0;
+  const genericStatus = componentStatus;
+  lastKnownComponentStatus = componentStatus;
+
+  if (newUpdates.length === 0 && !statusChangedWithoutIncident) return;
+
+  const targets = await getGuildsWithOutageAlertsEnabled();
+  if (targets.length === 0) return;
+
+  const embedsToSend: EmbedBuilder[] = newUpdates.map(({ incident, update }) => {
+    console.log(`AO3 incident update: "${incident.name}" -> ${update.status}`);
+    return buildIncidentUpdateEmbed(incident, update);
+  });
+
+  if (statusChangedWithoutIncident) {
+    console.log(`AO3 status changed with no incident published: -> ${genericStatus}`);
+    embedsToSend.push(buildGenericStatusEmbed(genericStatus));
+  }
+
+  for (const embed of embedsToSend) {
+    for (const { guildId, channelId } of targets) {
+      // Skip guilds this shard doesn't own.
+      const guild = client.guilds.cache.get(guildId);
+      if (!guild) continue;
+
+      const channel = guild.channels.cache.get(channelId);
+      if (!channel || !channel.isTextBased()) continue;
+
+      await channel.send({ embeds: [embed] }).catch((error) => {
+        console.error(`Failed to send outage alert to guild ${guildId} channel ${channelId}`, error);
+      });
+    }
+  }
+}
+
+export function startOutageMonitor(client: Client): void {
+  pollAndNotify(client).catch((error) => console.error("Initial outage status poll failed", error));
+  setInterval(() => {
+    pollAndNotify(client).catch((error) => console.error("Outage status poll failed", error));
+  }, POLL_INTERVAL_MS);
+}

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -6,7 +6,7 @@ import {
   userFieldSettings,
   workFieldSettings,
 } from "../db/schema.ts";
-import { eq } from "drizzle-orm";
+import { and, eq, isNotNull } from "drizzle-orm";
 
 import { db } from "../db/index.ts";
 
@@ -183,4 +183,18 @@ export async function replaceBlockedTags(guildId: string, tags: string[]): Promi
     await db.insert(blockedTags).values(tags.map((tag) => ({ guildSettingsId, tag })));
   }
   invalidateBundle(guildId);
+}
+
+// Outage alerts: guilds that opted in and picked a channel.
+export async function getGuildsWithOutageAlertsEnabled(): Promise<
+  { guildId: string; channelId: string }[]
+> {
+  const rows = await db.query.guildSettings.findMany({
+    where: and(eq(guildSettings.outageAlertsEnabled, true), isNotNull(guildSettings.outageAlertChannelId)),
+    columns: { guildId: true, outageAlertChannelId: true },
+  });
+
+  return rows
+    .filter((row): row is typeof row & { outageAlertChannelId: string } => row.outageAlertChannelId !== null)
+    .map((row) => ({ guildId: row.guildId, channelId: row.outageAlertChannelId }));
 }

--- a/utils/settingsPanel.ts
+++ b/utils/settingsPanel.ts
@@ -2,12 +2,16 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  ChannelSelectMenuBuilder,
+  ChannelType,
   CheckboxGroupBuilder,
   CheckboxGroupOptionBuilder,
   LabelBuilder,
   MessageFlags,
   ModalBuilder,
   PermissionFlagsBits,
+  RadioGroupBuilder,
+  RadioGroupOptionBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuOptionBuilder,
   TextInputBuilder,
@@ -20,20 +24,35 @@ import {
   EMBED_FIELD_GROUPS,
   FIELD_VALUE_HARD_CAP,
   getCategoryFieldStates,
+  getChapterDefaultTab,
   getFieldMaxLength,
   getFieldMaxLengthCap,
   getGuildSettingsBundle,
   getIgnoreChar,
+  getListResetToFirstPage,
+  getSeriesDefaultTab,
+  getWorkDefaultTab,
   isFieldEnabled,
   resetCategoryToDefaults,
   setCategoryFields,
+  setChapterDefaultTab,
   setFieldMaxLengths,
   setIgnoreChar,
+  setListResetToFirstPage,
+  setSeriesDefaultTab,
   setSingleFieldEnabled,
+  setWorkDefaultTab,
 } from "./embedFields.ts";
 import { getBlockedTags, setBlockedTags } from "./restrictions.ts";
+import { updateGuildSettings } from "./settings.ts";
 
-import type { EmbedFieldCategory, GuildSettingsBundle } from "./embedFields.ts";
+import type {
+  ChapterDefaultTab,
+  EmbedFieldCategory,
+  GuildSettingsBundle,
+  SeriesDefaultTab,
+  WorkDefaultTab,
+} from "./embedFields.ts";
 import type {
   ButtonInteraction,
   EmbedBuilder,
@@ -55,6 +74,32 @@ const CHECKBOX_GROUP_ID = "fields";
 const LENGTH_PREFIX = "length";
 const BLOCKED_TAGS_INPUT_ID = "blockedTags";
 const IGNORE_CHAR_INPUT_ID = "ignoreChar";
+const OUTAGE_CHANNEL_INPUT_ID = "outageChannel";
+const DEFAULT_TAB_INPUT_ID = "defaultTab";
+const LIST_RESET_INPUT_ID = "listReset";
+const LIST_RESET_OPTION_VALUE = "enabled";
+
+// Default-tab radio options per -inactivity category.
+const DEFAULT_TAB_OPTIONS: Partial<Record<EmbedFieldCategory, { value: string; label: string }[]>> = {
+  "work-inactivity": [
+    { value: "stats", label: "Stats" },
+    { value: "tags", label: "Tags" },
+    { value: "summary", label: "Summary" },
+    { value: "none", label: "Don't reset" },
+  ],
+  "chapter-inactivity": [
+    { value: "stats", label: "Stats" },
+    { value: "tags", label: "Tags" },
+    { value: "summary", label: "Summary" },
+    { value: "none", label: "Don't reset" },
+  ],
+  "series-inactivity": [
+    { value: "stats", label: "Stats" },
+    { value: "notes", label: "Notes" },
+    { value: "description", label: "Description" },
+    { value: "none", label: "Don't reset" },
+  ],
+};
 
 const DELETE_ORIGINAL_MESSAGE_KEY = "deleteOriginalMessage";
 const DELETE_ORIGINAL_MESSAGE_WARNING =
@@ -116,12 +161,41 @@ export async function buildGroupEmbed(
       getFieldMaxLength(bundle, "work-summary", "summary") > FIELD_VALUE_HARD_CAP &&
       isFieldEnabled(bundle, "general", "legacyWorkEmbed");
 
-    const lines =
-      categoryKey === "general"
-        ? `${fieldLines}\n\n**Ignore character:** \`${getIgnoreChar(bundle)}\``
-        : showsLegacySummaryCapNote
-          ? `${fieldLines}\n\n⚠️ *Legacy embed mode is on, so Summary is capped at ${FIELD_VALUE_HARD_CAP} characters here regardless of the length above — that only applies to the paginated embed.*`
-          : fieldLines;
+    const outageChannelId = bundle.guild?.outageAlertChannelId;
+    const outageChannelLine = outageChannelId ? `<#${outageChannelId}>` : "*not set*";
+
+    const defaultTabOptions = DEFAULT_TAB_OPTIONS[categoryKey];
+    const currentDefaultTab =
+      categoryKey === "work-inactivity"
+        ? getWorkDefaultTab(bundle)
+        : categoryKey === "chapter-inactivity"
+          ? getChapterDefaultTab(bundle)
+          : categoryKey === "series-inactivity"
+            ? getSeriesDefaultTab(bundle)
+            : null;
+    const defaultTabDisplayLabel = defaultTabOptions?.find((opt) => opt.value === currentDefaultTab)?.label;
+
+    // Extra info lines appended after the field checklist.
+    const extraLines: string[] = [];
+    if (categoryKey === "general") {
+      extraLines.push(`**Ignore character:** \`${getIgnoreChar(bundle)}\``, `**Outage alert channel:** ${outageChannelLine}`);
+    }
+    if (defaultTabDisplayLabel) extraLines.push(`**Default tab after inactivity:** ${defaultTabDisplayLabel}`);
+    if (categoryKey === "series-inactivity") {
+      extraLines.push(`${getListResetToFirstPage(bundle) ? "✅" : "❌"} /list: reset to page 1 after inactivity`);
+    }
+    if (showsLegacySummaryCapNote) {
+      extraLines.push(
+        `⚠️ *Legacy embed mode is on, so Summary is capped at ${FIELD_VALUE_HARD_CAP} characters here regardless of the length above — that only applies to the paginated embed.*`,
+      );
+    }
+
+    // Avoid a blank leading line when fieldLines is empty.
+    const lines = fieldLines && extraLines.length > 0
+      ? `${fieldLines}\n\n${extraLines.join("\n")}`
+      : extraLines.length > 0
+        ? extraLines.join("\n")
+        : fieldLines;
 
     embed.addFields({
       name: meta.title,
@@ -163,14 +237,14 @@ export function buildGroupComponents(groupIndex: number) {
       .setDisabled(groupIndex >= EMBED_FIELD_GROUPS.length - 1),
   );
 
-  const configureRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    group.categories.map((categoryKey) =>
-      new ButtonBuilder()
-        .setCustomId(`${CONFIGURE_PREFIX}:${groupIndex}:${categoryKey}`)
-        .setLabel(EMBED_FIELD_CATEGORIES[categoryKey].title)
-        .setStyle(ButtonStyle.Primary),
-    ),
+  const configureButtons = group.categories.map((categoryKey) =>
+    new ButtonBuilder()
+      .setCustomId(`${CONFIGURE_PREFIX}:${groupIndex}:${categoryKey}`)
+      .setLabel(EMBED_FIELD_CATEGORIES[categoryKey].title)
+      .setStyle(ButtonStyle.Primary),
   );
+
+  const configureRow = new ActionRowBuilder<ButtonBuilder>().addComponents(configureButtons);
 
   const resetRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
@@ -245,24 +319,35 @@ async function buildFieldsModal(
   const bundle = await getGuildSettingsBundle(guildId);
   const states = getCategoryFieldStates(bundle, categoryKey);
 
-  const checkboxGroup = new CheckboxGroupBuilder()
-    .setCustomId(CHECKBOX_GROUP_ID)
-    .setRequired(false)
-    .setMinValues(0)
-    .setMaxValues(states.length)
-    .setOptions(states.map(buildCheckboxOption));
+  // Skip the checkbox group for categories with no FieldDefs.
+  const checkboxLabel =
+    states.length > 0
+      ? [
+          (() => {
+            const checkboxGroup = new CheckboxGroupBuilder()
+              .setCustomId(CHECKBOX_GROUP_ID)
+              .setRequired(false)
+              .setMinValues(0)
+              .setMaxValues(states.length)
+              .setOptions(states.map(buildCheckboxOption));
 
-  const [label, description] =
-    categoryKey === "ratings"
-      ? ["Allowed ratings", "Uncheck a rating to block links to works with it."]
-      : categoryKey === "general"
-        ? ["Preferences", "Toggle general bot behavior for this server."]
-        : ["Visible fields", "Uncheck a field to hide it from this embed."];
+            const [label, description] =
+              categoryKey === "ratings"
+                ? ["Allowed ratings", "Uncheck a rating to block links to works with it."]
+                : categoryKey === "general"
+                  ? ["Preferences", "Toggle general bot behavior for this server."]
+                  : categoryKey === "gallery"
+                    ? ["Gallery settings", "Toggle gallery behavior for this server."]
+                    : categoryKey === "chapter-thumbnail"
+                      ? ["Thumbnail settings", "Toggle chapter thumbnail behavior for this server."]
+                      : categoryKey.endsWith("-inactivity")
+                        ? ["Inactivity settings", "Toggle inactivity-reset behavior for this embed."]
+                        : ["Visible fields", "Uncheck a field to hide it from this embed."];
 
-  const checkboxLabel = new LabelBuilder()
-    .setLabel(label)
-    .setDescription(description)
-    .setCheckboxGroupComponent(checkboxGroup);
+            return new LabelBuilder().setLabel(label).setDescription(description).setCheckboxGroupComponent(checkboxGroup);
+          })(),
+        ]
+      : [];
 
   const lengthLabels = states
     .filter((f) => f.maxLength)
@@ -301,10 +386,93 @@ async function buildFieldsModal(
         ]
       : [];
 
+  const outageChannelLabel =
+    categoryKey === "general"
+      ? [
+          (() => {
+            const select = new ChannelSelectMenuBuilder()
+              .setCustomId(OUTAGE_CHANNEL_INPUT_ID)
+              .setChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
+              .setRequired(false)
+              .setMinValues(0)
+              .setMaxValues(1);
+            if (bundle.guild?.outageAlertChannelId) select.setDefaultChannels(bundle.guild.outageAlertChannelId);
+
+            return new LabelBuilder()
+              .setLabel("Outage alert channel")
+              .setDescription('Where alerts are posted — "Post AO3 outage alerts" above must also be checked.')
+              .setChannelSelectMenuComponent(select);
+          })(),
+        ]
+      : [];
+
+  const defaultTabOptions = DEFAULT_TAB_OPTIONS[categoryKey];
+  const currentDefaultTab =
+    categoryKey === "work-inactivity"
+      ? getWorkDefaultTab(bundle)
+      : categoryKey === "chapter-inactivity"
+        ? getChapterDefaultTab(bundle)
+        : categoryKey === "series-inactivity"
+          ? getSeriesDefaultTab(bundle)
+          : null;
+
+  const defaultTabLabel =
+    defaultTabOptions && currentDefaultTab
+      ? [
+          new LabelBuilder()
+            .setLabel("Default tab after 5 min inactivity")
+            .setDescription("The original embed resets to this tab once nobody's clicked it for a while.")
+            .setRadioGroupComponent(
+              new RadioGroupBuilder()
+                .setCustomId(DEFAULT_TAB_INPUT_ID)
+                .setRequired(true)
+                .setOptions(
+                  defaultTabOptions.map((opt) =>
+                    new RadioGroupOptionBuilder()
+                      .setLabel(opt.label)
+                      .setValue(opt.value)
+                      .setDefault(opt.value === currentDefaultTab),
+                  ),
+                ),
+            ),
+        ]
+      : [];
+
+  // /list's reset toggle — hand-added, shown on the Series page.
+  const listResetLabel =
+    categoryKey === "series-inactivity"
+      ? [
+          new LabelBuilder()
+            .setLabel("/list command")
+            .setDescription("Settings for the /list command, which lists a series' works.")
+            .setCheckboxGroupComponent(
+              new CheckboxGroupBuilder()
+                .setCustomId(LIST_RESET_INPUT_ID)
+                .setRequired(false)
+                .setMinValues(0)
+                .setMaxValues(1)
+                .setOptions([
+                  new CheckboxGroupOptionBuilder()
+                    .setLabel("Reset to page 1 after inactivity")
+                    .setDescription("The original /list message jumps back to page 1 after 5 minutes with no clicks.")
+                    .setValue(LIST_RESET_OPTION_VALUE)
+                    .setDefault(getListResetToFirstPage(bundle)),
+                ]),
+            ),
+        ]
+      : [];
+
   return new ModalBuilder()
     .setCustomId(`${MODAL_PREFIX}:${groupIndex}:${categoryKey}`)
     .setTitle(`${group.title} — ${meta.title}`.slice(0, 45))
-    .addComponents(checkboxLabel, ...lengthLabels, ...ignoreCharLabel);
+    .addComponents(
+      ...checkboxLabel,
+      ...lengthLabels,
+      ...ignoreCharLabel,
+      ...outageChannelLabel,
+      ...defaultTabLabel,
+      ...listResetLabel,
+    );
 }
 
 // Restrictions doesn't fit the checkbox-group shape (it's a free-text list
@@ -340,7 +508,7 @@ async function buildRestrictionsModal(
         .setRequired(false)
         .setMaxLength(1000)
         .setValue(currentTags)
-        .setPlaceholder("e.g. Character Death, Non-Con, Rape/Non-Con"),
+        .setPlaceholder("e.g. Character Death, Non-Con, Abuse, Torture"),
     );
 
   return new ModalBuilder()
@@ -531,7 +699,9 @@ export async function handleSettingsPanelModalSubmit(
     categoryKey === "general" &&
     isFieldEnabled(await getGuildSettingsBundle(interaction.guildId), "general", DELETE_ORIGINAL_MESSAGE_KEY);
 
-  const submittedKeys = [...interaction.fields.getCheckboxGroup(CHECKBOX_GROUP_ID)];
+  // No checkbox group for categories with no FieldDefs.
+  const hasCheckboxGroup = EMBED_FIELD_CATEGORIES[categoryKey].fields.length > 0;
+  const submittedKeys = hasCheckboxGroup ? [...interaction.fields.getCheckboxGroup(CHECKBOX_GROUP_ID)] : [];
 
   // Turning this on is destructive and irreversible (deletes the user's
   // whole message, not just the link) in a way that isn't obvious from the
@@ -543,21 +713,42 @@ export async function handleSettingsPanelModalSubmit(
     !wasDeleteOriginalMessageEnabled &&
     submittedKeys.includes(DELETE_ORIGINAL_MESSAGE_KEY);
 
-  const enabledKeys = needsDeleteConfirmation
-    ? submittedKeys.filter((key) => key !== DELETE_ORIGINAL_MESSAGE_KEY)
-    : submittedKeys;
-  await setCategoryFields(interaction.guildId!, categoryKey, enabledKeys);
+  if (hasCheckboxGroup) {
+    const enabledKeys = needsDeleteConfirmation
+      ? submittedKeys.filter((key) => key !== DELETE_ORIGINAL_MESSAGE_KEY)
+      : submittedKeys;
+    await setCategoryFields(interaction.guildId!, categoryKey, enabledKeys);
 
-  const lengths: Record<string, number> = {};
-  for (const field of EMBED_FIELD_CATEGORIES[categoryKey].fields) {
-    if (!field.maxLength) continue;
-    const raw = interaction.fields.getTextInputValue(`${LENGTH_PREFIX}:${field.key}`);
-    lengths[field.key] = Number.parseInt(raw, 10);
+    const lengths: Record<string, number> = {};
+    for (const field of EMBED_FIELD_CATEGORIES[categoryKey].fields) {
+      if (!field.maxLength) continue;
+      const raw = interaction.fields.getTextInputValue(`${LENGTH_PREFIX}:${field.key}`);
+      lengths[field.key] = Number.parseInt(raw, 10);
+    }
+    await setFieldMaxLengths(interaction.guildId!, categoryKey, lengths);
   }
-  await setFieldMaxLengths(interaction.guildId!, categoryKey, lengths);
 
   if (categoryKey === "general") {
     await setIgnoreChar(interaction.guildId!, interaction.fields.getTextInputValue(IGNORE_CHAR_INPUT_ID));
+
+    const selectedChannel = interaction.fields.getSelectedChannels(OUTAGE_CHANNEL_INPUT_ID, false)?.first();
+    await updateGuildSettings(interaction.guildId!, { outageAlertChannelId: selectedChannel?.id ?? null });
+  }
+
+  if (DEFAULT_TAB_OPTIONS[categoryKey]) {
+    const selectedTab = interaction.fields.getRadioGroup(DEFAULT_TAB_INPUT_ID);
+    if (categoryKey === "work-inactivity") await setWorkDefaultTab(interaction.guildId!, selectedTab as WorkDefaultTab);
+    if (categoryKey === "chapter-inactivity") {
+      await setChapterDefaultTab(interaction.guildId!, selectedTab as ChapterDefaultTab);
+    }
+    if (categoryKey === "series-inactivity") {
+      await setSeriesDefaultTab(interaction.guildId!, selectedTab as SeriesDefaultTab);
+    }
+  }
+
+  if (categoryKey === "series-inactivity") {
+    const listResetEnabled = interaction.fields.getCheckboxGroup(LIST_RESET_INPUT_ID).includes(LIST_RESET_OPTION_VALUE);
+    await setListResetToFirstPage(interaction.guildId!, listResetEnabled);
   }
 
   if (needsDeleteConfirmation) {

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -22,6 +22,7 @@ export function getSeriesIdFromUrl(seriesURL: string): string {
 
 export interface RedirectSendResult {
   channelId: string;
+  message: any;
 }
 
 export interface RedirectableSendPayload {
@@ -48,19 +49,14 @@ export async function showTemporaryNotice(
   }, lifetimeMs);
 }
 
-// Sends an embed payload, redirecting to a channel/thread/forum configured
-// via /redirect if a rule matches. Falls back to editing waitingMsg in
-// place when no rule matches, the target is gone, or the guild has no
-// rules. Returns where it ended up so callers (e.g. a gallery follow-up)
-// can be told to land in the same place — resolveRedirectRule is
-// deterministic for the same guildId + meta, so a second independent call
-// with the same meta naturally lands on the same rule/thread.
+// Sends an embed, redirecting to a configured channel/thread/forum if a
+// /redirect rule matches. Returns where it landed and the sent message.
 export async function sendRedirectableEmbed(
   message: any,
   payload: RedirectableSendPayload,
   meta: { rating?: string; fandoms?: string[]; type: RedirectType },
   waitingMsg: any,
-): Promise<RedirectSendResult | null> {
+): Promise<RedirectSendResult> {
   const rule = message.guildId ? await resolveRedirectRule(message.guildId, meta) : null;
 
   if (rule && rule.destinationId !== message.channelId) {
@@ -68,16 +64,16 @@ export async function sendRedirectableEmbed(
 
     if (!dest) {
       console.warn(`Redirect target ${rule.destinationId} unavailable; falling back.`);
-      await waitingMsg.edit({ content: "", ...payload });
-      return null;
+      const edited = await waitingMsg.edit({ content: "", ...payload });
+      return { channelId: message.channelId, message: edited };
     }
 
     switch (rule.destinationType) {
       case "channel":
       case "thread": {
-        await dest.send(payload);
+        const sent = await dest.send(payload);
         await showTemporaryNotice(waitingMsg, `➡️ Sent to <#${rule.destinationId}>`, REDIRECT_NOTICE_LIFETIME_MS);
-        return { channelId: rule.destinationId };
+        return { channelId: rule.destinationId, message: sent };
       }
 
       case "forum": {
@@ -86,9 +82,9 @@ export async function sendRedirectableEmbed(
           const existing = await dest.threads.fetch(rule.forumThreadId).catch(() => null);
           if (existing) {
             if (existing.archived) await existing.setArchived(false).catch(() => {});
-            await existing.send(payload);
+            const sent = await existing.send(payload);
             await showTemporaryNotice(waitingMsg, `➡️ Sent to <#${rule.forumThreadId}>`, REDIRECT_NOTICE_LIFETIME_MS);
-            return { channelId: rule.forumThreadId };
+            return { channelId: rule.forumThreadId, message: sent };
           }
         }
 
@@ -98,11 +94,12 @@ export async function sendRedirectableEmbed(
           await updateRedirectRuleThreadId(message.guildId, rule.id, thread.id);
         }
         await showTemporaryNotice(waitingMsg, `➡️ Sent to new thread <#${thread.id}>`, REDIRECT_NOTICE_LIFETIME_MS);
-        return { channelId: thread.id };
+        const starterMessage = await thread.fetchStarterMessage();
+        return { channelId: thread.id, message: starterMessage };
       }
     }
   }
 
-  await waitingMsg.edit({ content: "", ...payload });
-  return null;
+  const edited = await waitingMsg.edit({ content: "", ...payload });
+  return { channelId: message.channelId, message: edited };
 }


### PR DESCRIPTION
- Chapter and series embeds now paginate into tabs instead of single truncated embeds
- Paginated embeds (Work/Chapter/Series/User/Gallery/list) reset to a configurable default page after 5 minutes of inactivity on the original message, never on ephemeral copies
- New AO3 outage alert monitor posts real incident updates from otwstatus.org's API, with a fallback notice for status changes that never got a published incident
- Settings panel restructured: each embed type gets its own Inactivity category, /list's reset setting lives on the Series page